### PR TITLE
Add onMapIdle event

### DIFF
--- a/.changeset/few-gifts-hide.md
+++ b/.changeset/few-gifts-hide.md
@@ -1,0 +1,5 @@
+---
+"@feltmaps/js-sdk": minor
+---
+
+Add onMapIdle event

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@feltmaps/js-sdk": "1.1.0"
+  },
+  "changesets": []
+}

--- a/docs/Main/FeltController.md
+++ b/docs/Main/FeltController.md
@@ -1021,3 +1021,38 @@ const unsubscribe = felt.onViewportMoveEnd({
 // later on...
 unsubscribe();
 ```
+
+***
+
+### onMapIdle()
+
+> **onMapIdle**(`args`: \{`handler`: () => `void`; }): `VoidFunction`
+
+Adds a listener for when the map is idle, which is defined as:
+
+* No transitions are in progress
+* The user is not interacting with the map, e.g. by panning or zooming
+* All tiles for the current viewport have been loaded
+* Any fade transitions (e.g. for labels) have completed
+
+#### Parameters
+
+| Parameter      | Type         |
+| -------------- | ------------ |
+| `args`         | `object`     |
+| `args.handler` | () => `void` |
+
+#### Returns
+
+`VoidFunction`
+
+A function to unsubscribe from the listener
+
+#### Example
+
+```typescript
+const unsubscribe = felt.onMapIdle({ handler: () => console.log("map is idle") });
+
+// later on...
+unsubscribe();
+```

--- a/docs/Viewport/ViewportController.md
+++ b/docs/Viewport/ViewportController.md
@@ -141,3 +141,38 @@ const unsubscribe = felt.onViewportMoveEnd({
 // later on...
 unsubscribe();
 ```
+
+***
+
+### onMapIdle()
+
+> **onMapIdle**(`args`: \{`handler`: () => `void`; }): `VoidFunction`
+
+Adds a listener for when the map is idle, which is defined as:
+
+* No transitions are in progress
+* The user is not interacting with the map, e.g. by panning or zooming
+* All tiles for the current viewport have been loaded
+* Any fade transitions (e.g. for labels) have completed
+
+#### Parameters
+
+| Parameter      | Type         |
+| -------------- | ------------ |
+| `args`         | `object`     |
+| `args.handler` | () => `void` |
+
+#### Returns
+
+`VoidFunction`
+
+A function to unsubscribe from the listener
+
+#### Example
+
+```typescript
+const unsubscribe = felt.onMapIdle({ handler: () => console.log("map is idle") });
+
+// later on...
+unsubscribe();
+```

--- a/etc/js-sdk.api.md
+++ b/etc/js-sdk.api.md
@@ -413,6 +413,9 @@ export { ViewportCenterZoom }
 export interface ViewportController {
     fitViewportToBounds(bounds: ViewportFitBoundsParams): void;
     getViewport(): Promise<ViewportState>;
+    onMapIdle(args: {
+        handler: () => void;
+    }): VoidFunction;
     onViewportMove(args: {
         handler: (viewport: ViewportState) => void;
     }): VoidFunction;

--- a/src/modules/viewport/controller.ts
+++ b/src/modules/viewport/controller.ts
@@ -14,6 +14,7 @@ export const viewportController = (feltWindow: Window): ViewportController => ({
   fitViewportToBounds: method(feltWindow, "fitViewportToBounds"),
   onViewportMove: listener(feltWindow, "onViewportMove"),
   onViewportMoveEnd: listener(feltWindow, "onViewportMoveEnd"),
+  onMapIdle: listener(feltWindow, "onMapIdle"),
 });
 
 /**
@@ -105,4 +106,24 @@ export interface ViewportController {
   onViewportMoveEnd(args: {
     handler: (viewport: ViewportState) => void;
   }): VoidFunction;
+
+  /**
+   * Adds a listener for when the map is idle, which is defined as:
+   * - No transitions are in progress
+   * - The user is not interacting with the map, e.g. by panning or zooming
+   * - All tiles for the current viewport have been loaded
+   * - Any fade transitions (e.g. for labels) have completed
+   *
+   * @returns A function to unsubscribe from the listener
+   *
+   * @event
+   * @example
+   * ```typescript
+   * const unsubscribe = felt.onMapIdle({ handler: () => console.log("map is idle") });
+   *
+   * // later on...
+   * unsubscribe();
+   * ```
+   */
+  onMapIdle(args: { handler: () => void }): VoidFunction;
 }

--- a/src/modules/viewport/schema.ts
+++ b/src/modules/viewport/schema.ts
@@ -24,10 +24,15 @@ const ViewportFitBoundsMessage = methodMessage(
 );
 const OnViewportMoveMessage = listenerMessageNoParams("onViewportMove");
 const OnViewportMoveEndMessage = listenerMessageNoParams("onViewportMoveEnd");
+const OnMapIdleMessage = listenerMessageNoParams("onMapIdle");
 
 export const viewportSchema = {
   methods: [GotoViewportMessage, GetViewportMessage, ViewportFitBoundsMessage],
-  listeners: [OnViewportMoveMessage, OnViewportMoveEndMessage],
+  listeners: [
+    OnViewportMoveMessage,
+    OnViewportMoveEndMessage,
+    OnMapIdleMessage,
+  ],
 } satisfies ModuleSchema;
 
 export type ViewportSchema = {
@@ -39,5 +44,6 @@ export type ViewportSchema = {
   listeners: {
     onViewportMove: Listener<void, ViewportState>;
     onViewportMoveEnd: Listener<void, ViewportState>;
+    onMapIdle: Listener<void, void>;
   };
 };


### PR DESCRIPTION
Adds the onMapIdle event which notifies users when all data is loaded, all transitions and all interactions are complete.

I've added this to the ViewportController which is almost right - seemed a little unnecessary to create a whole new controller for...map?...which is also really vague.

If we need more "map" things we can either add a new controller or perhaps rename the viewport controller to map or something like that.