### PR TITLE
Add setLayerLegendVisibility and setLayerGroupLegendVisibility methods definition

### DIFF
--- a/.changeset/hungry-hotels-end.md
+++ b/.changeset/hungry-hotels-end.md
@@ -1,0 +1,5 @@
+---
+"@feltmaps/js-sdk": minor
+---
+
+Add setLayerLegendVisibility and setLayerGroupLegendVisibility methods definition

--- a/docs/Layers/LayersController.md
+++ b/docs/Layers/LayersController.md
@@ -140,6 +140,32 @@ felt.setLayerStyle({ id: "layer-1", style: {
 
 ***
 
+### setLayerDisplayedInLegend()
+
+> **setLayerDisplayedInLegend**(`params`: \{`id`: `string`;`displayed`: `boolean`; }): `Promise`\<`void`>
+
+Set whether a layer is displayed in the legend.
+
+#### Parameters
+
+| Parameter          | Type      | Description                                          |
+| ------------------ | --------- | ---------------------------------------------------- |
+| `params`           | `object`  | -                                                    |
+| `params.id`        | `string`  | The id of the layer to set the displayed status for. |
+| `params.displayed` | `boolean` | Whether the layer should be displayed in the legend. |
+
+#### Returns
+
+`Promise`\<`void`>
+
+#### Example
+
+```typescript
+felt.setLayerDisplayedInLegend({ id: "layer-1", displayed: true });
+```
+
+***
+
 ### getLayerGroup()
 
 > **getLayerGroup**(`id`: `string`): `Promise`\<`null` | [`LayerGroup`](LayerGroup.md)>

--- a/docs/Layers/LayersController.md
+++ b/docs/Layers/LayersController.md
@@ -140,19 +140,17 @@ felt.setLayerStyle({ id: "layer-1", style: {
 
 ***
 
-### setLayerDisplayedInLegend()
+### setLayerLegendVisibility()
 
-> **setLayerDisplayedInLegend**(`params`: \{`id`: `string`;`displayed`: `boolean`; }): `Promise`\<`void`>
+> **setLayerLegendVisibility**(`params`: [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md)): `Promise`\<`void`>
 
-Set whether a layer is displayed in the legend.
+Hide or show layers with the given ids from the legend.
 
 #### Parameters
 
-| Parameter          | Type      | Description                                          |
-| ------------------ | --------- | ---------------------------------------------------- |
-| `params`           | `object`  | -                                                    |
-| `params.id`        | `string`  | The id of the layer to set the displayed status for. |
-| `params.displayed` | `boolean` | Whether the layer should be displayed in the legend. |
+| Parameter | Type                                                        |
+| --------- | ----------------------------------------------------------- |
+| `params`  | [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md) |
 
 #### Returns
 
@@ -161,7 +159,7 @@ Set whether a layer is displayed in the legend.
 #### Example
 
 ```typescript
-felt.setLayerDisplayedInLegend({ id: "layer-1", displayed: true });
+felt.setLayerLegendVisibility({ show: ["layer-1", "layer-2"], hide: ["layer-3"] });
 ```
 
 ***
@@ -239,6 +237,30 @@ Hide or show layer groups with the given ids.
 
 ```typescript
 felt.setLayerGroupVisibility({ show: ["layer-group-1", "layer-group-2"], hide: ["layer-group-3"] });
+```
+
+***
+
+### setLayerGroupLegendVisibility()
+
+> **setLayerGroupLegendVisibility**(`params`: [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md)): `Promise`\<`void`>
+
+Hide or show layer groups with the given ids from the legend.
+
+#### Parameters
+
+| Parameter | Type                                                        |
+| --------- | ----------------------------------------------------------- |
+| `params`  | [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md) |
+
+#### Returns
+
+`Promise`\<`void`>
+
+#### Example
+
+```typescript
+felt.setLayerGroupLegendVisibility({ show: ["layer-1", "layer-2"], hide: ["layer-3"] });
 ```
 
 ***

--- a/docs/Main/FeltController.md
+++ b/docs/Main/FeltController.md
@@ -311,6 +311,32 @@ felt.setLayerStyle({ id: "layer-1", style: {
 
 ***
 
+### setLayerDisplayedInLegend()
+
+> **setLayerDisplayedInLegend**(`params`: \{`id`: `string`;`displayed`: `boolean`; }): `Promise`\<`void`>
+
+Set whether a layer is displayed in the legend.
+
+#### Parameters
+
+| Parameter          | Type      | Description                                          |
+| ------------------ | --------- | ---------------------------------------------------- |
+| `params`           | `object`  | -                                                    |
+| `params.id`        | `string`  | The id of the layer to set the displayed status for. |
+| `params.displayed` | `boolean` | Whether the layer should be displayed in the legend. |
+
+#### Returns
+
+`Promise`\<`void`>
+
+#### Example
+
+```typescript
+felt.setLayerDisplayedInLegend({ id: "layer-1", displayed: true });
+```
+
+***
+
 ### getLayerGroup()
 
 > **getLayerGroup**(`id`: `string`): `Promise`\<`null` | [`LayerGroup`](../Layers/LayerGroup.md)>

--- a/docs/Main/FeltController.md
+++ b/docs/Main/FeltController.md
@@ -311,19 +311,17 @@ felt.setLayerStyle({ id: "layer-1", style: {
 
 ***
 
-### setLayerDisplayedInLegend()
+### setLayerLegendVisibility()
 
-> **setLayerDisplayedInLegend**(`params`: \{`id`: `string`;`displayed`: `boolean`; }): `Promise`\<`void`>
+> **setLayerLegendVisibility**(`params`: [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md)): `Promise`\<`void`>
 
-Set whether a layer is displayed in the legend.
+Hide or show layers with the given ids from the legend.
 
 #### Parameters
 
-| Parameter          | Type      | Description                                          |
-| ------------------ | --------- | ---------------------------------------------------- |
-| `params`           | `object`  | -                                                    |
-| `params.id`        | `string`  | The id of the layer to set the displayed status for. |
-| `params.displayed` | `boolean` | Whether the layer should be displayed in the legend. |
+| Parameter | Type                                                        |
+| --------- | ----------------------------------------------------------- |
+| `params`  | [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md) |
 
 #### Returns
 
@@ -332,7 +330,7 @@ Set whether a layer is displayed in the legend.
 #### Example
 
 ```typescript
-felt.setLayerDisplayedInLegend({ id: "layer-1", displayed: true });
+felt.setLayerLegendVisibility({ show: ["layer-1", "layer-2"], hide: ["layer-3"] });
 ```
 
 ***
@@ -410,6 +408,30 @@ Hide or show layer groups with the given ids.
 
 ```typescript
 felt.setLayerGroupVisibility({ show: ["layer-group-1", "layer-group-2"], hide: ["layer-group-3"] });
+```
+
+***
+
+### setLayerGroupLegendVisibility()
+
+> **setLayerGroupLegendVisibility**(`params`: [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md)): `Promise`\<`void`>
+
+Hide or show layer groups with the given ids from the legend.
+
+#### Parameters
+
+| Parameter | Type                                                        |
+| --------- | ----------------------------------------------------------- |
+| `params`  | [`SetVisibilityRequest`](../Shared/SetVisibilityRequest.md) |
+
+#### Returns
+
+`Promise`\<`void`>
+
+#### Example
+
+```typescript
+felt.setLayerGroupLegendVisibility({ show: ["layer-1", "layer-2"], hide: ["layer-3"] });
 ```
 
 ***

--- a/etc/js-sdk.api.md
+++ b/etc/js-sdk.api.md
@@ -296,6 +296,10 @@ export interface LayersController {
         options: LegendItemIdentifier;
         handler: (change: LegendItemChangeCallbackParams) => void;
     }): VoidFunction;
+    setLayerDisplayedInLegend(params: {
+        id: string;
+        displayed: boolean;
+    }): Promise<void>;
     setLayerFilters(params: {
         layerId: string;
         filters: Filters;

--- a/etc/js-sdk.api.md
+++ b/etc/js-sdk.api.md
@@ -296,16 +296,14 @@ export interface LayersController {
         options: LegendItemIdentifier;
         handler: (change: LegendItemChangeCallbackParams) => void;
     }): VoidFunction;
-    setLayerDisplayedInLegend(params: {
-        id: string;
-        displayed: boolean;
-    }): Promise<void>;
     setLayerFilters(params: {
         layerId: string;
         filters: Filters;
         note?: string;
     }): Promise<void>;
+    setLayerGroupLegendVisibility(params: SetVisibilityRequest): Promise<void>;
     setLayerGroupVisibility(visibility: SetVisibilityRequest): Promise<void>;
+    setLayerLegendVisibility(params: SetVisibilityRequest): Promise<void>;
     setLayerStyle(params: {
         id: string;
         style: object;

--- a/src/modules/layers/controller.ts
+++ b/src/modules/layers/controller.ts
@@ -25,13 +25,14 @@ export const layersController = (feltWindow: Window): LayersController => ({
   getLayers: method(feltWindow, "getLayers"),
   setLayerVisibility: method(feltWindow, "setLayerVisibility"),
   setLayerStyle: method(feltWindow, "setLayerStyle"),
-  setLayerDisplayedInLegend: method(feltWindow, "setLayerDisplayedInLegend"),
+  setLayerLegendVisibility: method(feltWindow, "setLayerLegendVisibility"),
   onLayerChange: listener(feltWindow, "onLayerChange"),
-
+  
   // groups
   getLayerGroup: method(feltWindow, "getLayerGroup"),
   getLayerGroups: method(feltWindow, "getLayerGroups"),
   setLayerGroupVisibility: method(feltWindow, "setLayerGroupVisibility"),
+  setLayerGroupLegendVisibility: method(feltWindow, "setLayerGroupLegendVisibility"),
   onLayerGroupChange: listener(feltWindow, "onLayerGroupChange"),
 
   // legend items
@@ -148,24 +149,14 @@ export interface LayersController {
   }): Promise<void>;
 
   /**
-   * Set whether a layer is displayed in the legend.
+   * Hide or show layers with the given ids from the legend.
    *
    * @example
    * ```typescript
-   * felt.setLayerDisplayedInLegend({ id: "layer-1", displayed: true });
+   * felt.setLayerLegendVisibility({ show: ["layer-1", "layer-2"], hide: ["layer-3"] });
    * ```
    */
-  setLayerDisplayedInLegend(params: {
-    /**
-     * The id of the layer to set the displayed status for.
-     */
-    id: string;
-
-    /**
-     * Whether the layer should be displayed in the legend.
-     */
-    displayed: boolean;
-  }): Promise<void>;
+  setLayerLegendVisibility(params: SetVisibilityRequest): Promise<void>;
 
   /**
    * Adds a listener for when a layer changes.
@@ -242,6 +233,16 @@ export interface LayersController {
    * ```
    */
   setLayerGroupVisibility(visibility: SetVisibilityRequest): Promise<void>;
+
+  /**
+   * Hide or show layer groups with the given ids from the legend.
+   *
+   * @example
+   * ```typescript
+   * felt.setLayerGroupLegendVisibility({ show: ["layer-1", "layer-2"], hide: ["layer-3"] });
+   * ```
+   */
+  setLayerGroupLegendVisibility(params: SetVisibilityRequest): Promise<void>;
 
   /**
    * Adds a listener for when a layer group changes.

--- a/src/modules/layers/controller.ts
+++ b/src/modules/layers/controller.ts
@@ -25,6 +25,7 @@ export const layersController = (feltWindow: Window): LayersController => ({
   getLayers: method(feltWindow, "getLayers"),
   setLayerVisibility: method(feltWindow, "setLayerVisibility"),
   setLayerStyle: method(feltWindow, "setLayerStyle"),
+  setLayerDisplayedInLegend: method(feltWindow, "setLayerDisplayedInLegend"),
   onLayerChange: listener(feltWindow, "onLayerChange"),
 
   // groups
@@ -144,6 +145,26 @@ export interface LayersController {
      * The style to set for the layer.
      */
     style: object;
+  }): Promise<void>;
+
+  /**
+   * Set whether a layer is displayed in the legend.
+   *
+   * @example
+   * ```typescript
+   * felt.setLayerDisplayedInLegend({ id: "layer-1", displayed: true });
+   * ```
+   */
+  setLayerDisplayedInLegend(params: {
+    /**
+     * The id of the layer to set the displayed status for.
+     */
+    id: string;
+
+    /**
+     * Whether the layer should be displayed in the legend.
+     */
+    displayed: boolean;
   }): Promise<void>;
 
   /**

--- a/src/modules/layers/controller.ts
+++ b/src/modules/layers/controller.ts
@@ -27,12 +27,15 @@ export const layersController = (feltWindow: Window): LayersController => ({
   setLayerStyle: method(feltWindow, "setLayerStyle"),
   setLayerLegendVisibility: method(feltWindow, "setLayerLegendVisibility"),
   onLayerChange: listener(feltWindow, "onLayerChange"),
-  
+
   // groups
   getLayerGroup: method(feltWindow, "getLayerGroup"),
   getLayerGroups: method(feltWindow, "getLayerGroups"),
   setLayerGroupVisibility: method(feltWindow, "setLayerGroupVisibility"),
-  setLayerGroupLegendVisibility: method(feltWindow, "setLayerGroupLegendVisibility"),
+  setLayerGroupLegendVisibility: method(
+    feltWindow,
+    "setLayerGroupLegendVisibility",
+  ),
   onLayerGroupChange: listener(feltWindow, "onLayerGroupChange"),
 
   // legend items

--- a/src/modules/layers/schema.ts
+++ b/src/modules/layers/schema.ts
@@ -42,6 +42,10 @@ const SetLayerStyleMessage = methodMessage(
   "setLayerStyle",
   z.object({ id: z.string(), style: z.object({}).passthrough() }),
 );
+const SetLayerDisplayedInLegendMessage = methodMessage(
+  "setLayerDisplayedInLegend",
+  z.object({ id: z.string(), displayed: z.boolean({}) }),
+);
 
 // LAYER GROUPS
 const GetGroupMessage = methodMessage("getLayerGroup", z.string());
@@ -102,6 +106,7 @@ export const layersSchema = {
     GetLayersMessage,
     SetLayerVisibilityMessage,
     SetLayerStyleMessage,
+    SetLayerDisplayedInLegendMessage,
 
     GetGroupMessage,
     GetGroupsMessage,
@@ -129,6 +134,7 @@ export type LayersSchema = {
     getLayers: Method<zInfer<typeof GetLayersMessage>, Array<Layer | null>>;
     setLayerVisibility: Method<zInfer<typeof SetLayerVisibilityMessage>, void>;
     setLayerStyle: Method<zInfer<typeof SetLayerStyleMessage>, void>;
+    setLayerDisplayedInLegend: Method<zInfer<typeof SetLayerDisplayedInLegendMessage>, void>;
 
     getLayerGroup: Method<zInfer<typeof GetGroupMessage>, LayerGroup | null>;
     getLayerGroups: Method<

--- a/src/modules/layers/schema.ts
+++ b/src/modules/layers/schema.ts
@@ -115,6 +115,7 @@ export const layersSchema = {
     GetGroupMessage,
     GetGroupsMessage,
     SetLayerGroupVisibilityMessage,
+    SetLayerGroupLegendVisibilityMessage,
 
     GetLegendItemMessage,
     GetLegendItemsMessage,

--- a/src/modules/layers/schema.ts
+++ b/src/modules/layers/schema.ts
@@ -138,7 +138,10 @@ export type LayersSchema = {
     getLayers: Method<zInfer<typeof GetLayersMessage>, Array<Layer | null>>;
     setLayerVisibility: Method<zInfer<typeof SetLayerVisibilityMessage>, void>;
     setLayerStyle: Method<zInfer<typeof SetLayerStyleMessage>, void>;
-    setLayerLegendVisibility: Method<zInfer<typeof SetLayerLegendVisibilityMessage>, void>;
+    setLayerLegendVisibility: Method<
+      zInfer<typeof SetLayerLegendVisibilityMessage>,
+      void
+    >;
 
     getLayerGroup: Method<zInfer<typeof GetGroupMessage>, LayerGroup | null>;
     getLayerGroups: Method<

--- a/src/modules/layers/schema.ts
+++ b/src/modules/layers/schema.ts
@@ -42,9 +42,9 @@ const SetLayerStyleMessage = methodMessage(
   "setLayerStyle",
   z.object({ id: z.string(), style: z.object({}).passthrough() }),
 );
-const SetLayerDisplayedInLegendMessage = methodMessage(
-  "setLayerDisplayedInLegend",
-  z.object({ id: z.string(), displayed: z.boolean({}) }),
+const SetLayerLegendVisibilityMessage = methodMessage(
+  "setLayerLegendVisibility",
+  SetVisibilityRequestSchema,
 );
 
 // LAYER GROUPS
@@ -55,6 +55,10 @@ const GetGroupsMessage = methodMessage(
 );
 const SetLayerGroupVisibilityMessage = methodMessage(
   "setLayerGroupVisibility",
+  SetVisibilityRequestSchema,
+);
+const SetLayerGroupLegendVisibilityMessage = methodMessage(
+  "setLayerGroupLegendVisibility",
   SetVisibilityRequestSchema,
 );
 const OnLayerGroupChangeMessage = listenerMessageWithParams(
@@ -106,7 +110,7 @@ export const layersSchema = {
     GetLayersMessage,
     SetLayerVisibilityMessage,
     SetLayerStyleMessage,
-    SetLayerDisplayedInLegendMessage,
+    SetLayerLegendVisibilityMessage,
 
     GetGroupMessage,
     GetGroupsMessage,
@@ -134,7 +138,7 @@ export type LayersSchema = {
     getLayers: Method<zInfer<typeof GetLayersMessage>, Array<Layer | null>>;
     setLayerVisibility: Method<zInfer<typeof SetLayerVisibilityMessage>, void>;
     setLayerStyle: Method<zInfer<typeof SetLayerStyleMessage>, void>;
-    setLayerDisplayedInLegend: Method<zInfer<typeof SetLayerDisplayedInLegendMessage>, void>;
+    setLayerLegendVisibility: Method<zInfer<typeof SetLayerLegendVisibilityMessage>, void>;
 
     getLayerGroup: Method<zInfer<typeof GetGroupMessage>, LayerGroup | null>;
     getLayerGroups: Method<
@@ -143,6 +147,10 @@ export type LayersSchema = {
     >;
     setLayerGroupVisibility: Method<
       zInfer<typeof SetLayerGroupVisibilityMessage>,
+      void
+    >;
+    setLayerGroupLegendVisibility: Method<
+      zInfer<typeof SetLayerGroupLegendVisibilityMessage>,
       void
     >;
 


### PR DESCRIPTION
This PR adds capabilities to the layer's API for toggling layer legend visibility, as well as for the layer groups.  New methods are `setLayerLegendVisibility` and `setLayerGroupLegendVisibility` which accept a single object param which will include `show: string[]` and/or `hide: string[]`.