### PR TITLE
Add onLayerFiltersChange listener

### DIFF
--- a/.changeset/great-elephants-cry.md
+++ b/.changeset/great-elephants-cry.md
@@ -1,0 +1,5 @@
+---
+"@feltmaps/js-sdk": minor
+---
+
+Add onLayerFiltersChange to allow listening to changes to layer filters, be it ephemeral, style or widget filters that changed.

--- a/docs/Layers/LayersController.md
+++ b/docs/Layers/LayersController.md
@@ -745,3 +745,51 @@ const unsubscribe = felt.onLegendItemChange({
 // later on...
 unsubscribe();
 ```
+
+***
+
+## onLayerFiltersChange()
+
+> **onLayerFiltersChange**(`params`: \{ `options`: \{ `layerId`: `string`; }; `handler`: (`change`: [`LayerFilters`](LayerFilters.md)) => `void`; }): `VoidFunction`
+
+Adds a listener for when a layer's filters change.
+
+### Parameters
+
+| Parameter                | Type                                                                                                           |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `params`                 | \{ `options`: \{ `layerId`: `string`; }; `handler`: (`change`: [`LayerFilters`](LayerFilters.md)) => `void`; } |
+| `params.options`         | \{ `layerId`: `string`; }                                                                                      |
+| `params.options.layerId` | `string`                                                                                                       |
+| `params.handler`         | (`change`: [`LayerFilters`](LayerFilters.md)) => `void`                                                        |
+
+### Returns
+
+`VoidFunction`
+
+A function to unsubscribe from the listener
+
+### Remarks
+
+This event fires whenever any type of filter changes on the layer, including
+ephemeral filters set via the SDK, style-based filters, or filters set through
+the Felt UI via Components.
+
+### Example
+
+```typescript
+const unsubscribe = felt.onLayerFiltersChange({
+  options: { layerId: "layer-1" },
+  handler: ({combined, ephemeral, style, components}) => {
+    console.log("Layer filters updated:", {
+      combined,  // All filters combined
+      ephemeral, // Filters set via SDK
+      style,     // Filters from layer style
+      components // Filters from UI components
+    });
+  },
+});
+
+// later on...
+unsubscribe();
+```

--- a/docs/Main/FeltController.md
+++ b/docs/Main/FeltController.md
@@ -1704,6 +1704,54 @@ unsubscribe();
 
 ***
 
+## onLayerFiltersChange()
+
+> **onLayerFiltersChange**(`params`: \{ `options`: \{ `layerId`: `string`; }; `handler`: (`change`: [`LayerFilters`](../Layers/LayerFilters.md)) => `void`; }): `VoidFunction`
+
+Adds a listener for when a layer's filters change.
+
+### Parameters
+
+| Parameter                | Type                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `params`                 | \{ `options`: \{ `layerId`: `string`; }; `handler`: (`change`: [`LayerFilters`](../Layers/LayerFilters.md)) => `void`; } |
+| `params.options`         | \{ `layerId`: `string`; }                                                                                                |
+| `params.options.layerId` | `string`                                                                                                                 |
+| `params.handler`         | (`change`: [`LayerFilters`](../Layers/LayerFilters.md)) => `void`                                                        |
+
+### Returns
+
+`VoidFunction`
+
+A function to unsubscribe from the listener
+
+### Remarks
+
+This event fires whenever any type of filter changes on the layer, including
+ephemeral filters set via the SDK, style-based filters, or filters set through
+the Felt UI via Components.
+
+### Example
+
+```typescript
+const unsubscribe = felt.onLayerFiltersChange({
+  options: { layerId: "layer-1" },
+  handler: ({combined, ephemeral, style, components}) => {
+    console.log("Layer filters updated:", {
+      combined,  // All filters combined
+      ephemeral, // Filters set via SDK
+      style,     // Filters from layer style
+      components // Filters from UI components
+    });
+  },
+});
+
+// later on...
+unsubscribe();
+```
+
+***
+
 ## onSelectionChange()
 
 > **onSelectionChange**(`params`: \{ `handler`: (`change`: \{ `selection`: [`EntityNode`](../Selection/EntityNode.md)\[]; }) => `void`; }): `VoidFunction`

--- a/etc/js-sdk.api.md
+++ b/etc/js-sdk.api.md
@@ -409,6 +409,12 @@ export interface LayersController {
         handler: (
         change: LayerChangeCallbackParams) => void;
     }): VoidFunction;
+    onLayerFiltersChange(params: {
+        options: {
+            layerId: string;
+        };
+        handler: (change: LayerFilters) => void;
+    }): VoidFunction;
     onLayerGroupChange(args: {
         options: {
             id: string;

--- a/src/modules/layers/controller.ts
+++ b/src/modules/layers/controller.ts
@@ -55,6 +55,7 @@ export const layersController = (feltWindow: Window): LayersController => ({
   // filters
   getLayerFilters: method(feltWindow, "getLayerFilters"),
   setLayerFilters: method(feltWindow, "setLayerFilters"),
+  onLayerFiltersChange: listener(feltWindow, "onLayerFiltersChange"),
 
   // rendered features
   getRenderedFeatures: method(feltWindow, "getRenderedFeatures"),
@@ -398,6 +399,42 @@ export interface LayersController {
      */
     note?: string;
   }): Promise<void>;
+
+  /**
+   * Adds a listener for when a layer's filters change.
+   *
+   * @returns A function to unsubscribe from the listener
+   *
+   * @remarks
+   * This event fires whenever any type of filter changes on the layer, including
+   * ephemeral filters set via the SDK, style-based filters, or filters set through
+   * the Felt UI via Components.
+   *
+   * @event
+   * @example
+   * ```typescript
+   * const unsubscribe = felt.onLayerFiltersChange({
+   *   options: { layerId: "layer-1" },
+   *   handler: ({combined, ephemeral, style, components}) => {
+   *     console.log("Layer filters updated:", {
+   *       combined,  // All filters combined
+   *       ephemeral, // Filters set via SDK
+   *       style,     // Filters from layer style
+   *       components // Filters from UI components
+   *     });
+   *   },
+   * });
+   *
+   * // later on...
+   * unsubscribe();
+   * ```
+   */
+  onLayerFiltersChange(params: {
+    options: {
+      layerId: string;
+    };
+    handler: (change: LayerFilters) => void;
+  }): VoidFunction;
 
   /**
    * Get the features that are currently **rendered** on the map in the viewport.

--- a/src/modules/layers/schema.ts
+++ b/src/modules/layers/schema.ts
@@ -105,6 +105,10 @@ const SetFiltersMessage = methodMessage(
     note: z.string().optional(),
   }),
 );
+const OnLayerFiltersChangeMessage = listenerMessageWithParams(
+  "onLayerFiltersChange",
+  z.object({ layerId: z.string() }),
+);
 
 // RENDERED FEATURES
 const GetRenderedFeaturesMessage = methodMessage(
@@ -158,6 +162,7 @@ export const layersSchema = {
     OnLayerChangeMessage,
     OnLayerGroupChangeMessage,
     OnLegendItemChangeMessage,
+    OnLayerFiltersChangeMessage,
   ],
 } satisfies ModuleSchema;
 
@@ -236,6 +241,10 @@ export type LayersSchema = {
     onLegendItemChange: Listener<
       zInfer<typeof OnLegendItemChangeMessage.shape.options>,
       LegendItemChangeCallbackParams
+    >;
+    onLayerFiltersChange: Listener<
+      zInfer<typeof OnLayerFiltersChangeMessage.shape.options>,
+      LayerFilters
     >;
   };
 };


### PR DESCRIPTION
## What this does

Adds `onLayerFiltersChange` listener with documentation.

It's separated like this (and not a layer change, for instance) because the filters for a particular layer can come from many sources, and we already have get and set for LayerFilters so adding the Change follows the pattern.