### PR TITLE
Ensure geometry styles are retained when creating a layer with a file

### DIFF
--- a/.changeset/silly-rocks-judge.md
+++ b/.changeset/silly-rocks-judge.md
@@ -1,0 +1,5 @@
+---
+"@feltmaps/js-sdk": patch
+---
+
+Fix per-geometry styling for created layers

--- a/src/modules/layers/controller.ts
+++ b/src/modules/layers/controller.ts
@@ -49,11 +49,11 @@ export const layersController = (feltWindow: Window): LayersController => ({
 
     // convert file to array buffer
     return {
-      ...params,
       source: {
         type: "application/geo+json",
         name: params.source.name,
         arrayBuffer: await params.source.file.arrayBuffer(),
+        geometryStyles: params.source.geometryStyles,
       },
     };
   }),

--- a/src/modules/layers/controller.ts
+++ b/src/modules/layers/controller.ts
@@ -50,10 +50,8 @@ export const layersController = (feltWindow: Window): LayersController => ({
     // convert file to array buffer
     return {
       source: {
-        type: "application/geo+json",
-        name: params.source.name,
+        ...params.source,
         arrayBuffer: await params.source.file.arrayBuffer(),
-        geometryStyles: params.source.geometryStyles,
       },
     };
   }),


### PR DESCRIPTION
`geometryStyles` were getting omitted when `createLayer` was called with a `File` source. This fixes that. 