### PR TITLE
Throw errors from methods when validation fails

### DIFF
--- a/.changeset/kind-radios-grin.md
+++ b/.changeset/kind-radios-grin.md
@@ -1,0 +1,5 @@
+---
+"@feltmaps/js-sdk": minor
+---
+
+Reject promises when method handlers are invalid

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,4 +1,5 @@
 import { z, ZodError } from "zod";
+import { createErrorMessage } from "./lib/errors";
 import type { FeltHandlers } from "./lib/interface";
 import type { ModuleSchema } from "./lib/ModuleSchema";
 import { allModules } from "./modules/main/schema";
@@ -47,7 +48,7 @@ export function createMessageHandler(
     const result = AllMessagesSchema.safeParse(message.data);
     if (!result.success) {
       options?.onInvalidMessage?.(message.data, result.error);
-      message.ports[0]?.postMessage({ __error__: result.error.message });
+      message.ports[0]?.postMessage(createErrorMessage(result.error.message));
       return;
     }
 
@@ -88,9 +89,7 @@ export function createMessageHandler(
         const result = await handler(data.params);
         message.ports[0]?.postMessage(result);
       } catch (error) {
-        message.ports[0]?.postMessage({
-          __error__: errorStringFromUnknown(error),
-        });
+        message.ports[0]?.postMessage(createErrorMessage(error));
       }
     }
   }
@@ -100,22 +99,6 @@ export function createMessageHandler(
   return () => {
     feltWindow.removeEventListener("message", handleMessage);
   };
-}
-
-function errorStringFromUnknown(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === "object" && error !== null && "message" in error) {
-    return String(error.message);
-  }
-
-  if (typeof error === "string") {
-    return error;
-  }
-
-  return "Unknown error";
 }
 
 const mergedSchemas = {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -47,6 +47,7 @@ export function createMessageHandler(
     const result = AllMessagesSchema.safeParse(message.data);
     if (!result.success) {
       options?.onInvalidMessage?.(message.data, result.error);
+      message.ports[0]?.postMessage({ __error__: result.error.message });
       return;
     }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,26 @@
+export function isErrorMessage(
+  event: MessageEvent,
+): event is MessageEvent<{ __error__: string }> {
+  return (
+    event.data && typeof event.data === "object" && "__error__" in event.data
+  );
+}
+
+export function createErrorMessage(errorish: unknown): { __error__: string } {
+  return { __error__: errorStringFromUnknown(errorish) };
+}
+function errorStringFromUnknown(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String(error.message);
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unknown error";
+}

--- a/src/lib/interface.ts
+++ b/src/lib/interface.ts
@@ -1,4 +1,5 @@
 import type { AllModules } from "~/modules/main/schema";
+import { isErrorMessage } from "./errors";
 import type { PromiseOrNot, UnionToIntersection } from "./utils";
 
 export type FeltHandlers = {
@@ -172,12 +173,4 @@ export function method<TKey extends keyof StandardMethods, R>(
       };
     });
   };
-}
-
-function isErrorMessage(
-  event: MessageEvent,
-): event is MessageEvent<{ __error__: string }> {
-  return (
-    event.data && typeof event.data === "object" && "__error__" in event.data
-  );
 }

--- a/src/lib/interface.ts
+++ b/src/lib/interface.ts
@@ -111,6 +111,9 @@ export function listener<TEventName extends keyof ListenerSpec>(
     );
 
     messageChannel.port1.onmessage = (event) => {
+      // we cannot send errors down the message channel - listeners unfortunately cannot have invalid
+      // messages thrown or rejected, because their only communication mechanism is the message channel,
+      // and that is only designed to receive successful events.
       if (!isErrorMessage(event)) {
         handler(event.data);
       }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -168,7 +168,7 @@ describe("Felt SDK integration", () => {
     expect(onInvalidMessage).toHaveBeenCalledOnce();
   });
 
-  test("All client messages are handled", async () => {
+  test("No client messages are considered unknown", async () => {
     const client = await Felt.connect(window);
 
     // iterate through all the functions in the client, calling them


### PR DESCRIPTION
Throw errors from methods when validation fails. Previously it would only report those validation failures via onInvalidMessage, but numerous people were annoyed by this, and it would leave promises never resolving/rejecting.

Now, methods (not listeners) will reject if their message is invalid.