### PR TITLE
Add support for customizing legend title

### DIFF
--- a/.changeset/fifty-bulldogs-train.md
+++ b/.changeset/fifty-bulldogs-train.md
@@ -1,0 +1,5 @@
+---
+"@feltmaps/js-sdk": patch
+---
+
+Add support for customizing legend title

--- a/docs/UI/UiControlsOptions.md
+++ b/docs/UI/UiControlsOptions.md
@@ -16,6 +16,24 @@ true
 
 ***
 
+## legendTitle?
+
+> `optional` **legendTitle**: `string` | `boolean`
+
+Customize the title of the legend.
+
+* If true, map title is used.
+* If false, literal "Legend" is used.
+* For a custom legend title, set as string.
+
+### Default Value
+
+```ts
+true
+```
+
+***
+
 ## cooperativeGestures?
 
 > `optional` **cooperativeGestures**: `boolean`

--- a/etc/js-sdk.api.md
+++ b/etc/js-sdk.api.md
@@ -251,6 +251,7 @@ const FeltEmbedOptionsSchema: z.ZodObject<{
     token: z.ZodOptional<z.ZodString>;
     uiControls: z.ZodOptional<z.ZodObject<{
         showLegend: z.ZodOptional<z.ZodBoolean>;
+        legendTitle: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodBoolean]>>;
         cooperativeGestures: z.ZodOptional<z.ZodBoolean>;
         fullScreenButton: z.ZodOptional<z.ZodBoolean>;
         geolocation: z.ZodOptional<z.ZodBoolean>;
@@ -258,6 +259,7 @@ const FeltEmbedOptionsSchema: z.ZodObject<{
         scaleBar: z.ZodOptional<z.ZodBoolean>;
     }, "strip", z.ZodTypeAny, {
         showLegend?: boolean | undefined;
+        legendTitle?: string | boolean | undefined;
         cooperativeGestures?: boolean | undefined;
         fullScreenButton?: boolean | undefined;
         geolocation?: boolean | undefined;
@@ -265,6 +267,7 @@ const FeltEmbedOptionsSchema: z.ZodObject<{
         scaleBar?: boolean | undefined;
     }, {
         showLegend?: boolean | undefined;
+        legendTitle?: string | boolean | undefined;
         cooperativeGestures?: boolean | undefined;
         fullScreenButton?: boolean | undefined;
         geolocation?: boolean | undefined;
@@ -301,6 +304,7 @@ const FeltEmbedOptionsSchema: z.ZodObject<{
     token?: string | undefined;
     uiControls?: {
         showLegend?: boolean | undefined;
+        legendTitle?: string | boolean | undefined;
         cooperativeGestures?: boolean | undefined;
         fullScreenButton?: boolean | undefined;
         geolocation?: boolean | undefined;
@@ -319,6 +323,7 @@ const FeltEmbedOptionsSchema: z.ZodObject<{
     token?: string | undefined;
     uiControls?: {
         showLegend?: boolean | undefined;
+        legendTitle?: string | boolean | undefined;
         cooperativeGestures?: boolean | undefined;
         fullScreenButton?: boolean | undefined;
         geolocation?: boolean | undefined;
@@ -685,6 +690,7 @@ export interface UiControlsOptions extends O<typeof UiControlsOptionsSchema> {
 // @internal (undocumented)
 const UiControlsOptionsSchema: z.ZodObject<{
     showLegend: z.ZodOptional<z.ZodBoolean>;
+    legendTitle: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodBoolean]>>;
     cooperativeGestures: z.ZodOptional<z.ZodBoolean>;
     fullScreenButton: z.ZodOptional<z.ZodBoolean>;
     geolocation: z.ZodOptional<z.ZodBoolean>;
@@ -692,6 +698,7 @@ const UiControlsOptionsSchema: z.ZodObject<{
     scaleBar: z.ZodOptional<z.ZodBoolean>;
 }, "strip", z.ZodTypeAny, {
     showLegend?: boolean | undefined;
+    legendTitle?: string | boolean | undefined;
     cooperativeGestures?: boolean | undefined;
     fullScreenButton?: boolean | undefined;
     geolocation?: boolean | undefined;
@@ -699,6 +706,7 @@ const UiControlsOptionsSchema: z.ZodObject<{
     scaleBar?: boolean | undefined;
 }, {
     showLegend?: boolean | undefined;
+    legendTitle?: string | boolean | undefined;
     cooperativeGestures?: boolean | undefined;
     fullScreenButton?: boolean | undefined;
     geolocation?: boolean | undefined;

--- a/src/modules/main/index.ts
+++ b/src/modules/main/index.ts
@@ -76,6 +76,7 @@ export const Felt = {
       geolocation: "geolocation",
       zoomControls: "zoomControls",
       scaleBar: "scaleBar",
+      legendTitle: "legendTitle",
     };
 
     const uiControlsOptions = {

--- a/src/modules/ui/types.ts
+++ b/src/modules/ui/types.ts
@@ -20,6 +20,17 @@ export const UiControlsOptionsSchema = z.object({
   showLegend: z.boolean().optional(),
 
   /**
+   * Customize the title of the legend.
+   *
+   *   - If true, map title is used.
+   *   - If false, literal "Legend" is used.
+   *   - For a custom legend title, set as string.
+   *
+   * @defaultValue true
+   */
+  legendTitle: z.union([z.string(), z.boolean()]).optional(),
+
+  /**
    * When co-operative gestures are enabled, the pan and zoom gestures are
    * adjusted to work better when the map is embedded in another page.
    *


### PR DESCRIPTION
This PR adds a new UI control option named `legendTitle`, useful to control what's shown as the legend title. There are three different options:

- true (default): map title will be shown
- false: "Legend" literal will be shown.
- string: whatever the user sets there.