### PR TITLE
Derive return types from controllers

### DIFF
--- a/docs/Main/FeltController.md
+++ b/docs/Main/FeltController.md
@@ -1340,7 +1340,7 @@ felt.clearSelection({ elements: true });
 
 ## setTool()
 
-> **setTool**(`tool`: `null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`): `void`
+> **setTool**(`tool`: `null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`): `void`
 
 Sets the tool to use for drawing elements on the map.
 
@@ -1348,7 +1348,7 @@ Sets the tool to use for drawing elements on the map.
 
 | Parameter | Type                                                                                                                                         | Description      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `tool`    | `null` \| `"text"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` \| `"link"` | The tool to set. |
+| `tool`    | `null` \| `"text"` \| `"link"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` | The tool to set. |
 
 ### Returns
 
@@ -1368,13 +1368,13 @@ await felt.setTool(null);
 
 ## getTool()
 
-> **getTool**(): `Promise`\<`null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`>
+> **getTool**(): `Promise`\<`null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`>
 
 Gets the current tool, if any is in use.
 
 ### Returns
 
-`Promise`\<`null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`>
+`Promise`\<`null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`>
 
 The current tool, or `null` if no tool is in use.
 
@@ -1388,7 +1388,7 @@ const tool = await felt.getTool(); // "marker", "polygon", etc.
 
 ## onToolChange()
 
-> **onToolChange**(`args`: \{ `handler`: (`tool`: `null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`) => `void`; }): `VoidFunction`
+> **onToolChange**(`args`: \{ `handler`: (`tool`: `null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`) => `void`; }): `VoidFunction`
 
 Listens for changes to the current tool.
 
@@ -1396,8 +1396,8 @@ Listens for changes to the current tool.
 
 | Parameter      | Type                                                                                                                                                                              | Description                                                              |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `args`         | \{ `handler`: (`tool`: `null` \| `"text"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` \| `"link"`) => `void`; } | -                                                                        |
-| `args.handler` | (`tool`: `null` \| `"text"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` \| `"link"`) => `void`                  | This callback is called with the current tool whenever the tool changes. |
+| `args`         | \{ `handler`: (`tool`: `null` \| `"text"` \| `"link"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"`) => `void`; } | -                                                                        |
+| `args.handler` | (`tool`: `null` \| `"text"` \| `"link"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"`) => `void`                  | This callback is called with the current tool whenever the tool changes. |
 
 ### Returns
 

--- a/docs/Tools/ToolType.md
+++ b/docs/Tools/ToolType.md
@@ -1,3 +1,3 @@
 ***
 
-> **ToolType**: `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`
+> **ToolType**: `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`

--- a/docs/Tools/ToolsController.md
+++ b/docs/Tools/ToolsController.md
@@ -10,7 +10,7 @@ The Tools controller allows you to let users draw elements on the map.
 
 ## setTool()
 
-> **setTool**(`tool`: `null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`): `void`
+> **setTool**(`tool`: `null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`): `void`
 
 Sets the tool to use for drawing elements on the map.
 
@@ -18,7 +18,7 @@ Sets the tool to use for drawing elements on the map.
 
 | Parameter | Type                                                                                                                                         | Description      |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `tool`    | `null` \| `"text"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` \| `"link"` | The tool to set. |
+| `tool`    | `null` \| `"text"` \| `"link"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` | The tool to set. |
 
 ### Returns
 
@@ -38,13 +38,13 @@ await felt.setTool(null);
 
 ## getTool()
 
-> **getTool**(): `Promise`\<`null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`>
+> **getTool**(): `Promise`\<`null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`>
 
 Gets the current tool, if any is in use.
 
 ### Returns
 
-`Promise`\<`null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`>
+`Promise`\<`null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`>
 
 The current tool, or `null` if no tool is in use.
 
@@ -58,7 +58,7 @@ const tool = await felt.getTool(); // "marker", "polygon", etc.
 
 ## onToolChange()
 
-> **onToolChange**(`args`: \{ `handler`: (`tool`: `null` | `"text"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"` | `"link"`) => `void`; }): `VoidFunction`
+> **onToolChange**(`args`: \{ `handler`: (`tool`: `null` | `"text"` | `"link"` | `"note"` | `"pin"` | `"line"` | `"route"` | `"polygon"` | `"circle"` | `"marker"` | `"highlighter"`) => `void`; }): `VoidFunction`
 
 Listens for changes to the current tool.
 
@@ -66,8 +66,8 @@ Listens for changes to the current tool.
 
 | Parameter      | Type                                                                                                                                                                              | Description                                                              |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `args`         | \{ `handler`: (`tool`: `null` \| `"text"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` \| `"link"`) => `void`; } | -                                                                        |
-| `args.handler` | (`tool`: `null` \| `"text"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"` \| `"link"`) => `void`                  | This callback is called with the current tool whenever the tool changes. |
+| `args`         | \{ `handler`: (`tool`: `null` \| `"text"` \| `"link"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"`) => `void`; } | -                                                                        |
+| `args.handler` | (`tool`: `null` \| `"text"` \| `"link"` \| `"note"` \| `"pin"` \| `"line"` \| `"route"` \| `"polygon"` \| `"circle"` \| `"marker"` \| `"highlighter"`) => `void`                  | This callback is called with the current tool whenever the tool changes. |
 
 ### Returns
 

--- a/etc/js-sdk.api.md
+++ b/etc/js-sdk.api.md
@@ -4,141 +4,151 @@
 
 ```ts
 
-import { aH as AggregationConfig } from './types-0PFYQhMS.js';
-import { aI as AggregationMethod } from './types-0PFYQhMS.js';
-import { q as CircleElementCreate } from './types-0PFYQhMS.js';
-import { r as CircleElementRead } from './types-0PFYQhMS.js';
-import { s as CircleElementUpdate } from './types-0PFYQhMS.js';
-import { b6 as CircleToolSettings } from './types-0PFYQhMS.js';
-import { C as ConfigurableToolType } from './types-0PFYQhMS.js';
-import { a1 as CreateLayersFromGeoJsonParams } from './types-0PFYQhMS.js';
-import { a2 as DataOnlyLayer } from './types-0PFYQhMS.js';
-import { E as Element_2 } from './types-0PFYQhMS.js';
-import { d as ElementChangeCallbackParams } from './types-0PFYQhMS.js';
-import { f as ElementCreate } from './types-0PFYQhMS.js';
-import { b as ElementGroup } from './types-0PFYQhMS.js';
-import { e as ElementGroupChangeCallbackParams } from './types-0PFYQhMS.js';
-import { aQ as ElementGroupNode } from './types-0PFYQhMS.js';
-import { aR as ElementNode } from './types-0PFYQhMS.js';
-import { g as ElementUpdate } from './types-0PFYQhMS.js';
-import { i as EntityNode } from './types-0PFYQhMS.js';
-import { aS as FeatureNode } from './types-0PFYQhMS.js';
-import { F as FeatureSelection } from './types-0PFYQhMS.js';
-import { aV as FeltBoundary } from './types-0PFYQhMS.js';
-import { a3 as FeltTiledVectorSource } from './types-0PFYQhMS.js';
-import { aW as FeltZoom } from './types-0PFYQhMS.js';
-import { az as FilterExpression } from './types-0PFYQhMS.js';
-import { aA as FilterLogicGate } from './types-0PFYQhMS.js';
-import { aC as Filters } from './types-0PFYQhMS.js';
-import { aB as FilterTernary } from './types-0PFYQhMS.js';
-import { a4 as GeoJsonDataVectorSource } from './types-0PFYQhMS.js';
-import { aX as GeoJsonFeature } from './types-0PFYQhMS.js';
-import { a5 as GeoJsonFileVectorSource } from './types-0PFYQhMS.js';
-import { G as GeoJsonGeometry } from './types-0PFYQhMS.js';
-import { aY as GeoJsonProperties } from './types-0PFYQhMS.js';
-import { a6 as GeoJsonUrlVectorSource } from './types-0PFYQhMS.js';
-import { aD as GeometryFilter } from './types-0PFYQhMS.js';
-import { c as GetElementGroupsConstraint } from './types-0PFYQhMS.js';
-import { a as GetElementsConstraint } from './types-0PFYQhMS.js';
-import { aJ as GetLayerCalculationParams } from './types-0PFYQhMS.js';
-import { aK as GetLayerCategoriesGroup } from './types-0PFYQhMS.js';
-import { aL as GetLayerCategoriesParams } from './types-0PFYQhMS.js';
-import { a7 as GetLayerGroupsConstraint } from './types-0PFYQhMS.js';
-import { aM as GetLayerHistogramBin } from './types-0PFYQhMS.js';
-import { aN as GetLayerHistogramParams } from './types-0PFYQhMS.js';
-import { a8 as GetLayersConstraint } from './types-0PFYQhMS.js';
-import { a9 as GetRenderedFeaturesConstraint } from './types-0PFYQhMS.js';
-import { H as HighlighterElementCreate } from './types-0PFYQhMS.js';
-import { t as HighlighterElementRead } from './types-0PFYQhMS.js';
-import { u as HighlighterElementUpdate } from './types-0PFYQhMS.js';
-import { b7 as HighlighterToolSettings } from './types-0PFYQhMS.js';
-import { v as ImageElementCreate } from './types-0PFYQhMS.js';
-import { w as ImageElementRead } from './types-0PFYQhMS.js';
-import { x as ImageElementUpdate } from './types-0PFYQhMS.js';
-import { I as InputToolSettings } from './types-0PFYQhMS.js';
-import { aZ as LatLng } from './types-0PFYQhMS.js';
-import { aa as Layer } from './types-0PFYQhMS.js';
-import { aF as LayerBoundaries } from './types-0PFYQhMS.js';
-import { aG as LayerBoundary } from './types-0PFYQhMS.js';
-import { ab as LayerChangeCallbackParams } from './types-0PFYQhMS.js';
-import { ac as LayerCommon } from './types-0PFYQhMS.js';
-import { ap as LayerFeature } from './types-0PFYQhMS.js';
-import { aE as LayerFilters } from './types-0PFYQhMS.js';
-import { ad as LayerGroup } from './types-0PFYQhMS.js';
-import { ae as LayerGroupChangeCallbackParams } from './types-0PFYQhMS.js';
-import { aT as LayerGroupNode } from './types-0PFYQhMS.js';
-import { aU as LayerNode } from './types-0PFYQhMS.js';
-import { af as LayerProcessingStatus } from './types-0PFYQhMS.js';
-import { ar as LayerSchema } from './types-0PFYQhMS.js';
-import { as as LayerSchemaAttribute } from './types-0PFYQhMS.js';
-import { at as LayerSchemaBooleanAttribute } from './types-0PFYQhMS.js';
-import { au as LayerSchemaCommonAttribute } from './types-0PFYQhMS.js';
-import { av as LayerSchemaDateAttribute } from './types-0PFYQhMS.js';
-import { aw as LayerSchemaDateTimeAttribute } from './types-0PFYQhMS.js';
-import { ax as LayerSchemaNumericAttribute } from './types-0PFYQhMS.js';
-import { ay as LayerSchemaTextAttribute } from './types-0PFYQhMS.js';
-import { L as LayersController } from './types-0PFYQhMS.js';
-import { ag as LegendItem } from './types-0PFYQhMS.js';
-import { ah as LegendItemChangeCallbackParams } from './types-0PFYQhMS.js';
-import { ai as LegendItemIdentifier } from './types-0PFYQhMS.js';
-import { aj as LegendItemsConstraint } from './types-0PFYQhMS.js';
-import { a_ as LineStringGeometry } from './types-0PFYQhMS.js';
-import { b8 as LineToolSettings } from './types-0PFYQhMS.js';
-import { y as LinkElementRead } from './types-0PFYQhMS.js';
-import { a$ as LngLatTuple } from './types-0PFYQhMS.js';
-import { h as MapDetails } from './types-0PFYQhMS.js';
-import { M as MapInteractionEvent } from './types-0PFYQhMS.js';
-import { A as MarkerElementCreate } from './types-0PFYQhMS.js';
-import { B as MarkerElementRead } from './types-0PFYQhMS.js';
-import { D as MarkerElementUpdate } from './types-0PFYQhMS.js';
-import { b9 as MarkerToolSettings } from './types-0PFYQhMS.js';
-import { aO as MultiAggregationConfig } from './types-0PFYQhMS.js';
-import { b0 as MultiLineStringGeometry } from './types-0PFYQhMS.js';
-import { b1 as MultiPointGeometry } from './types-0PFYQhMS.js';
-import { b2 as MultiPolygonGeometry } from './types-0PFYQhMS.js';
-import { N as NoteElementCreate } from './types-0PFYQhMS.js';
-import { J as NoteElementRead } from './types-0PFYQhMS.js';
-import { K as NoteElementUpdate } from './types-0PFYQhMS.js';
-import { ba as NoteToolSettings } from './types-0PFYQhMS.js';
-import { P as PathElementCreate } from './types-0PFYQhMS.js';
-import { O as PathElementRead } from './types-0PFYQhMS.js';
-import { Q as PathElementUpdate } from './types-0PFYQhMS.js';
-import { bb as PinToolSettings } from './types-0PFYQhMS.js';
-import { R as PlaceElementCreate } from './types-0PFYQhMS.js';
-import { U as PlaceElementRead } from './types-0PFYQhMS.js';
-import { W as PlaceElementUpdate } from './types-0PFYQhMS.js';
-import { bc as PlaceFrame } from './types-0PFYQhMS.js';
-import { bd as PlaceSymbol } from './types-0PFYQhMS.js';
-import { b3 as PointGeometry } from './types-0PFYQhMS.js';
-import { X as PolygonElementCreate } from './types-0PFYQhMS.js';
-import { Y as PolygonElementRead } from './types-0PFYQhMS.js';
-import { Z as PolygonElementUpdate } from './types-0PFYQhMS.js';
-import { b4 as PolygonGeometry } from './types-0PFYQhMS.js';
-import { be as PolygonToolSettings } from './types-0PFYQhMS.js';
-import { ak as RasterBand } from './types-0PFYQhMS.js';
-import { al as RasterLayer } from './types-0PFYQhMS.js';
-import { am as RasterLayerSource } from './types-0PFYQhMS.js';
-import { aq as RasterValue } from './types-0PFYQhMS.js';
-import { bf as RouteToolSettings } from './types-0PFYQhMS.js';
-import { m as SetViewportCenterZoomParams } from './types-0PFYQhMS.js';
-import { S as SetVisibilityRequest } from './types-0PFYQhMS.js';
-import { l as SortConfig } from './types-0PFYQhMS.js';
-import { b5 as SortDirection } from './types-0PFYQhMS.js';
-import { _ as TextElementCreate } from './types-0PFYQhMS.js';
-import { $ as TextElementRead } from './types-0PFYQhMS.js';
-import { a0 as TextElementUpdate } from './types-0PFYQhMS.js';
-import { bg as TextToolSettings } from './types-0PFYQhMS.js';
-import { k as ToolSettingsChangeEvent } from './types-0PFYQhMS.js';
-import { j as ToolSettingsMap } from './types-0PFYQhMS.js';
-import { T as ToolType } from './types-0PFYQhMS.js';
-import { an as UpdateLayerParams } from './types-0PFYQhMS.js';
-import { aP as ValueConfiguration } from './types-0PFYQhMS.js';
-import { ao as VectorLayer } from './types-0PFYQhMS.js';
-import { p as ViewportCenterZoom } from './types-0PFYQhMS.js';
-import { n as ViewportConstraints } from './types-0PFYQhMS.js';
-import { o as ViewportFitBoundsParams } from './types-0PFYQhMS.js';
-import { V as ViewportState } from './types-0PFYQhMS.js';
-import { z } from './types-0PFYQhMS.js';
+import { av as AggregationConfig } from './controller-Cw1fDvl0.js';
+import { aw as AggregationMethod } from './controller-Cw1fDvl0.js';
+import { C as CircleElementCreate } from './controller-Cw1fDvl0.js';
+import { a as CircleElementRead } from './controller-Cw1fDvl0.js';
+import { b as CircleElementUpdate } from './controller-Cw1fDvl0.js';
+import { b3 as CircleToolSettings } from './controller-Cw1fDvl0.js';
+import { b4 as ConfigurableToolType } from './controller-Cw1fDvl0.js';
+import { K as CreateLayersFromGeoJsonParams } from './controller-Cw1fDvl0.js';
+import { O as DataOnlyLayer } from './controller-Cw1fDvl0.js';
+import { E as Element_2 } from './controller-Cw1fDvl0.js';
+import { c as ElementChangeCallbackParams } from './controller-Cw1fDvl0.js';
+import { d as ElementCreate } from './controller-Cw1fDvl0.js';
+import { e as ElementGroup } from './controller-Cw1fDvl0.js';
+import { f as ElementGroupChangeCallbackParams } from './controller-Cw1fDvl0.js';
+import { aH as ElementGroupNode } from './controller-Cw1fDvl0.js';
+import { aI as ElementNode } from './controller-Cw1fDvl0.js';
+import { B as ElementsController } from './controller-Cw1fDvl0.js';
+import { g as ElementUpdate } from './controller-Cw1fDvl0.js';
+import { aJ as EntityNode } from './controller-Cw1fDvl0.js';
+import { aK as FeatureNode } from './controller-Cw1fDvl0.js';
+import { aL as FeatureSelection } from './controller-Cw1fDvl0.js';
+import { aP as FeltBoundary } from './controller-Cw1fDvl0.js';
+import { F as FeltController } from './controller-Cw1fDvl0.js';
+import { Q as FeltTiledVectorSource } from './controller-Cw1fDvl0.js';
+import { aQ as FeltZoom } from './controller-Cw1fDvl0.js';
+import { an as FilterExpression } from './controller-Cw1fDvl0.js';
+import { ao as FilterLogicGate } from './controller-Cw1fDvl0.js';
+import { aq as Filters } from './controller-Cw1fDvl0.js';
+import { ap as FilterTernary } from './controller-Cw1fDvl0.js';
+import { R as GeoJsonDataVectorSource } from './controller-Cw1fDvl0.js';
+import { aR as GeoJsonFeature } from './controller-Cw1fDvl0.js';
+import { S as GeoJsonFileVectorSource } from './controller-Cw1fDvl0.js';
+import { aS as GeoJsonGeometry } from './controller-Cw1fDvl0.js';
+import { aT as GeoJsonProperties } from './controller-Cw1fDvl0.js';
+import { W as GeoJsonUrlVectorSource } from './controller-Cw1fDvl0.js';
+import { ar as GeometryFilter } from './controller-Cw1fDvl0.js';
+import { G as GetElementGroupsConstraint } from './controller-Cw1fDvl0.js';
+import { h as GetElementsConstraint } from './controller-Cw1fDvl0.js';
+import { ax as GetLayerCalculationParams } from './controller-Cw1fDvl0.js';
+import { ay as GetLayerCategoriesGroup } from './controller-Cw1fDvl0.js';
+import { az as GetLayerCategoriesParams } from './controller-Cw1fDvl0.js';
+import { X as GetLayerGroupsConstraint } from './controller-Cw1fDvl0.js';
+import { aA as GetLayerHistogramBin } from './controller-Cw1fDvl0.js';
+import { aB as GetLayerHistogramParams } from './controller-Cw1fDvl0.js';
+import { Y as GetLayersConstraint } from './controller-Cw1fDvl0.js';
+import { Z as GetRenderedFeaturesConstraint } from './controller-Cw1fDvl0.js';
+import { H as HighlighterElementCreate } from './controller-Cw1fDvl0.js';
+import { i as HighlighterElementRead } from './controller-Cw1fDvl0.js';
+import { j as HighlighterElementUpdate } from './controller-Cw1fDvl0.js';
+import { b5 as HighlighterToolSettings } from './controller-Cw1fDvl0.js';
+import { I as ImageElementCreate } from './controller-Cw1fDvl0.js';
+import { k as ImageElementRead } from './controller-Cw1fDvl0.js';
+import { l as ImageElementUpdate } from './controller-Cw1fDvl0.js';
+import { b6 as InputToolSettings } from './controller-Cw1fDvl0.js';
+import { J as InteractionsController } from './controller-Cw1fDvl0.js';
+import { aU as LatLng } from './controller-Cw1fDvl0.js';
+import { _ as Layer } from './controller-Cw1fDvl0.js';
+import { at as LayerBoundaries } from './controller-Cw1fDvl0.js';
+import { au as LayerBoundary } from './controller-Cw1fDvl0.js';
+import { $ as LayerChangeCallbackParams } from './controller-Cw1fDvl0.js';
+import { a0 as LayerCommon } from './controller-Cw1fDvl0.js';
+import { ad as LayerFeature } from './controller-Cw1fDvl0.js';
+import { as as LayerFilters } from './controller-Cw1fDvl0.js';
+import { a1 as LayerGroup } from './controller-Cw1fDvl0.js';
+import { a2 as LayerGroupChangeCallbackParams } from './controller-Cw1fDvl0.js';
+import { aM as LayerGroupNode } from './controller-Cw1fDvl0.js';
+import { aN as LayerNode } from './controller-Cw1fDvl0.js';
+import { a3 as LayerProcessingStatus } from './controller-Cw1fDvl0.js';
+import { af as LayerSchema } from './controller-Cw1fDvl0.js';
+import { ag as LayerSchemaAttribute } from './controller-Cw1fDvl0.js';
+import { ah as LayerSchemaBooleanAttribute } from './controller-Cw1fDvl0.js';
+import { ai as LayerSchemaCommonAttribute } from './controller-Cw1fDvl0.js';
+import { aj as LayerSchemaDateAttribute } from './controller-Cw1fDvl0.js';
+import { ak as LayerSchemaDateTimeAttribute } from './controller-Cw1fDvl0.js';
+import { al as LayerSchemaNumericAttribute } from './controller-Cw1fDvl0.js';
+import { am as LayerSchemaTextAttribute } from './controller-Cw1fDvl0.js';
+import { aE as LayersController } from './controller-Cw1fDvl0.js';
+import { a4 as LegendItem } from './controller-Cw1fDvl0.js';
+import { a5 as LegendItemChangeCallbackParams } from './controller-Cw1fDvl0.js';
+import { a6 as LegendItemIdentifier } from './controller-Cw1fDvl0.js';
+import { a7 as LegendItemsConstraint } from './controller-Cw1fDvl0.js';
+import { aV as LineStringGeometry } from './controller-Cw1fDvl0.js';
+import { b7 as LineToolSettings } from './controller-Cw1fDvl0.js';
+import { L as LinkElementRead } from './controller-Cw1fDvl0.js';
+import { aW as LngLatTuple } from './controller-Cw1fDvl0.js';
+import { aF as MapDetails } from './controller-Cw1fDvl0.js';
+import { D as MapInteractionEvent } from './controller-Cw1fDvl0.js';
+import { M as MarkerElementCreate } from './controller-Cw1fDvl0.js';
+import { m as MarkerElementRead } from './controller-Cw1fDvl0.js';
+import { n as MarkerElementUpdate } from './controller-Cw1fDvl0.js';
+import { b8 as MarkerToolSettings } from './controller-Cw1fDvl0.js';
+import { aG as MiscController } from './controller-Cw1fDvl0.js';
+import { aC as MultiAggregationConfig } from './controller-Cw1fDvl0.js';
+import { aX as MultiLineStringGeometry } from './controller-Cw1fDvl0.js';
+import { aY as MultiPointGeometry } from './controller-Cw1fDvl0.js';
+import { aZ as MultiPolygonGeometry } from './controller-Cw1fDvl0.js';
+import { N as NoteElementCreate } from './controller-Cw1fDvl0.js';
+import { o as NoteElementRead } from './controller-Cw1fDvl0.js';
+import { p as NoteElementUpdate } from './controller-Cw1fDvl0.js';
+import { b9 as NoteToolSettings } from './controller-Cw1fDvl0.js';
+import { bk as OnMapInteractionsOptions } from './controller-Cw1fDvl0.js';
+import { P as PathElementCreate } from './controller-Cw1fDvl0.js';
+import { q as PathElementRead } from './controller-Cw1fDvl0.js';
+import { r as PathElementUpdate } from './controller-Cw1fDvl0.js';
+import { ba as PinToolSettings } from './controller-Cw1fDvl0.js';
+import { s as PlaceElementCreate } from './controller-Cw1fDvl0.js';
+import { t as PlaceElementRead } from './controller-Cw1fDvl0.js';
+import { u as PlaceElementUpdate } from './controller-Cw1fDvl0.js';
+import { bb as PlaceFrame } from './controller-Cw1fDvl0.js';
+import { bc as PlaceSymbol } from './controller-Cw1fDvl0.js';
+import { a_ as PointGeometry } from './controller-Cw1fDvl0.js';
+import { v as PolygonElementCreate } from './controller-Cw1fDvl0.js';
+import { w as PolygonElementRead } from './controller-Cw1fDvl0.js';
+import { x as PolygonElementUpdate } from './controller-Cw1fDvl0.js';
+import { a$ as PolygonGeometry } from './controller-Cw1fDvl0.js';
+import { bd as PolygonToolSettings } from './controller-Cw1fDvl0.js';
+import { a8 as RasterBand } from './controller-Cw1fDvl0.js';
+import { a9 as RasterLayer } from './controller-Cw1fDvl0.js';
+import { aa as RasterLayerSource } from './controller-Cw1fDvl0.js';
+import { ae as RasterValue } from './controller-Cw1fDvl0.js';
+import { be as RouteToolSettings } from './controller-Cw1fDvl0.js';
+import { aO as SelectionController } from './controller-Cw1fDvl0.js';
+import { bm as SetViewportCenterZoomParams } from './controller-Cw1fDvl0.js';
+import { b0 as SetVisibilityRequest } from './controller-Cw1fDvl0.js';
+import { b1 as SortConfig } from './controller-Cw1fDvl0.js';
+import { b2 as SortDirection } from './controller-Cw1fDvl0.js';
+import { T as TextElementCreate } from './controller-Cw1fDvl0.js';
+import { y as TextElementRead } from './controller-Cw1fDvl0.js';
+import { A as TextElementUpdate } from './controller-Cw1fDvl0.js';
+import { bf as TextToolSettings } from './controller-Cw1fDvl0.js';
+import { bj as ToolsController } from './controller-Cw1fDvl0.js';
+import { bg as ToolSettingsChangeEvent } from './controller-Cw1fDvl0.js';
+import { bh as ToolSettingsMap } from './controller-Cw1fDvl0.js';
+import { bi as ToolType } from './controller-Cw1fDvl0.js';
+import { bl as UiController } from './controller-Cw1fDvl0.js';
+import { U as UiControlsOptions } from './controller-Cw1fDvl0.js';
+import { ab as UpdateLayerParams } from './controller-Cw1fDvl0.js';
+import { aD as ValueConfiguration } from './controller-Cw1fDvl0.js';
+import { ac as VectorLayer } from './controller-Cw1fDvl0.js';
+import { V as ViewportCenterZoom } from './controller-Cw1fDvl0.js';
+import { bn as ViewportConstraints } from './controller-Cw1fDvl0.js';
+import { bq as ViewportController } from './controller-Cw1fDvl0.js';
+import { bo as ViewportFitBoundsParams } from './controller-Cw1fDvl0.js';
+import { bp as ViewportState } from './controller-Cw1fDvl0.js';
+import { z } from './controller-Cw1fDvl0.js';
 import { z as z_2 } from 'zod';
 
 export { AggregationConfig }
@@ -173,49 +183,7 @@ export { ElementGroupNode }
 
 export { ElementNode }
 
-// @public
-export interface ElementsController {
-    createElement(element: ElementCreate): Promise<Element_2>;
-    deleteElement(id: string): Promise<void>;
-    getElement(
-    id: string): Promise<Element_2 | null>;
-    getElementGeometry(
-    id: string): Promise<GeoJsonGeometry | null>;
-    getElementGroup(id: string): Promise<ElementGroup | null>;
-    getElementGroups(
-    constraint?: GetElementGroupsConstraint): Promise<Array<ElementGroup | null>>;
-    getElements(
-    constraint?: GetElementsConstraint): Promise<Array<Element_2 | null>>;
-    onElementChange(args: {
-        options: {
-            id: string;
-        };
-        handler: (
-        change: ElementChangeCallbackParams) => void;
-    }): VoidFunction;
-    onElementCreate(args: {
-        handler: (change: ElementChangeCallbackParams) => void;
-    }): VoidFunction;
-    onElementCreateEnd(args: {
-        handler: (params: {
-            element: Element_2;
-        }) => void;
-    }): VoidFunction;
-    onElementDelete(args: {
-        options: {
-            id: string;
-        };
-        handler: () => void;
-    }): VoidFunction;
-    onElementGroupChange(args: {
-        options: {
-            id: string;
-        };
-        handler: (change: ElementGroupChangeCallbackParams) => void;
-    }): VoidFunction;
-    setElementGroupVisibility(visibility: SetVisibilityRequest): Promise<void>;
-    updateElement(element: ElementUpdate): Promise<Element_2>;
-}
+export { ElementsController }
 
 export { ElementUpdate }
 
@@ -233,10 +201,7 @@ export const Felt: {
 
 export { FeltBoundary }
 
-// @public
-export interface FeltController extends ViewportController, UiController, LayersController, ElementsController, SelectionController, InteractionsController, ToolsController, InteractionsController, MiscController {
-    iframe: HTMLIFrameElement | null;
-}
+export { FeltController }
 
 // Warning: (ae-forgotten-export) The symbol "FeltEmbedOptionsSchema" needs to be exported by the entry point client.d.ts
 //
@@ -399,16 +364,7 @@ export { ImageElementUpdate }
 
 export { InputToolSettings }
 
-// @public
-export interface InteractionsController {
-    onPointerClick(params: {
-        handler: (event: MapInteractionEvent) => void;
-    }): VoidFunction;
-    onPointerMove(
-    params: {
-        handler: (event: MapInteractionEvent) => void;
-    }): VoidFunction;
-}
+export { InteractionsController }
 
 export { LatLng }
 
@@ -482,10 +438,7 @@ export { MarkerElementUpdate }
 
 export { MarkerToolSettings }
 
-// @public
-export interface MiscController {
-    getMapDetails(): Promise<MapDetails>;
-}
+export { MiscController }
 
 export { MultiAggregationConfig }
 
@@ -503,11 +456,7 @@ export { NoteElementUpdate }
 
 export { NoteToolSettings }
 
-// Warning: (ae-forgotten-export) The symbol "UiOnMapInteractionsOptionsSchema" needs to be exported by the entry point client.d.ts
-//
-// @public
-export interface OnMapInteractionsOptions extends z<typeof UiOnMapInteractionsOptionsSchema> {
-}
+export { OnMapInteractionsOptions }
 
 export { PathElementCreate }
 
@@ -549,20 +498,7 @@ export { RasterValue }
 
 export { RouteToolSettings }
 
-// @public
-export interface SelectionController {
-    clearSelection(params?: {
-        features?: boolean;
-        elements?: boolean;
-    }): Promise<void>;
-    getSelection(): Promise<EntityNode[]>;
-    onSelectionChange(params: {
-        handler: (change: {
-            selection: EntityNode[];
-        }) => void;
-    }): VoidFunction;
-    selectFeature(params: FeatureSelection): Promise<void>;
-}
+export { SelectionController }
 
 export { SetViewportCenterZoomParams }
 
@@ -580,19 +516,7 @@ export { TextElementUpdate }
 
 export { TextToolSettings }
 
-// @public
-export interface ToolsController {
-    getTool(): Promise<ToolType | null>;
-    getToolSettings<T extends ConfigurableToolType>(tool: T): Promise<ToolSettingsMap[T]>;
-    onToolChange(args: {
-        handler: (tool: ToolType | null) => void;
-    }): VoidFunction;
-    onToolSettingsChange(args: {
-        handler: (settings: ToolSettingsChangeEvent) => void;
-    }): VoidFunction;
-    setTool(tool: ToolType | null): void;
-    setToolSettings(settings: InputToolSettings): void;
-}
+export { ToolsController }
 
 export { ToolSettingsChangeEvent }
 
@@ -600,67 +524,9 @@ export { ToolSettingsMap }
 
 export { ToolType }
 
-// @public
-export interface UiController {
-    hideLayerDataTable(): Promise<void>;
-    setOnMapInteractionsUi(options: OnMapInteractionsOptions): void;
-    showLayerDataTable(params?: {
-        layerId: string;
-        sorting?: SortConfig;
-    }): Promise<void>;
-    updateUiControls(controls: UiControlsOptions): void;
-}
+export { UiController }
 
-// Warning: (ae-forgotten-export) The symbol "UiControlsOptionsSchema" needs to be exported by the entry point client.d.ts
-//
-// @public (undocumented)
-export interface UiControlsOptions extends z<typeof UiControlsOptionsSchema> {
-}
-
-// @internal (undocumented)
-const UiControlsOptionsSchema: z_2.ZodObject<{
-    showLegend: z_2.ZodOptional<z_2.ZodBoolean>;
-    cooperativeGestures: z_2.ZodOptional<z_2.ZodBoolean>;
-    fullScreenButton: z_2.ZodOptional<z_2.ZodBoolean>;
-    geolocation: z_2.ZodOptional<z_2.ZodBoolean>;
-    zoomControls: z_2.ZodOptional<z_2.ZodBoolean>;
-    scaleBar: z_2.ZodOptional<z_2.ZodBoolean>;
-}, "strip", z_2.ZodTypeAny, {
-    showLegend?: boolean | undefined;
-    cooperativeGestures?: boolean | undefined;
-    fullScreenButton?: boolean | undefined;
-    geolocation?: boolean | undefined;
-    zoomControls?: boolean | undefined;
-    scaleBar?: boolean | undefined;
-}, {
-    showLegend?: boolean | undefined;
-    cooperativeGestures?: boolean | undefined;
-    fullScreenButton?: boolean | undefined;
-    geolocation?: boolean | undefined;
-    zoomControls?: boolean | undefined;
-    scaleBar?: boolean | undefined;
-}>;
-
-// @internal (undocumented)
-const UiOnMapInteractionsOptionsSchema: z_2.ZodObject<{
-    featureSelectPanel: z_2.ZodOptional<z_2.ZodBoolean>;
-    featureHoverPanel: z_2.ZodOptional<z_2.ZodBoolean>;
-    elementSelectPanel: z_2.ZodOptional<z_2.ZodBoolean>;
-    linkClickOpen: z_2.ZodOptional<z_2.ZodBoolean>;
-    imageLightboxOpen: z_2.ZodOptional<z_2.ZodBoolean>;
-}, "strip", z_2.ZodTypeAny, {
-    featureSelectPanel?: boolean | undefined;
-    featureHoverPanel?: boolean | undefined;
-    elementSelectPanel?: boolean | undefined;
-    linkClickOpen?: boolean | undefined;
-    imageLightboxOpen?: boolean | undefined;
-}, {
-    featureSelectPanel?: boolean | undefined;
-    featureHoverPanel?: boolean | undefined;
-    elementSelectPanel?: boolean | undefined;
-    linkClickOpen?: boolean | undefined;
-    imageLightboxOpen?: boolean | undefined;
-}>;
+export { UiControlsOptions }
 
 export { UpdateLayerParams }
 
@@ -672,23 +538,7 @@ export { ViewportCenterZoom }
 
 export { ViewportConstraints }
 
-// @public
-export interface ViewportController {
-    fitViewportToBounds(bounds: ViewportFitBoundsParams): void;
-    getViewport(): Promise<ViewportState>;
-    getViewportConstraints(): Promise<ViewportConstraints | null>;
-    onMapIdle(args: {
-        handler: () => void;
-    }): VoidFunction;
-    onViewportMove(args: {
-        handler: (viewport: ViewportState) => void;
-    }): VoidFunction;
-    onViewportMoveEnd(args: {
-        handler: (viewport: ViewportState) => void;
-    }): VoidFunction;
-    setViewport(viewport: SetViewportCenterZoomParams): void;
-    setViewportConstraints(constraints: Partial<ViewportConstraints> | null): void;
-}
+export { ViewportController }
 
 export { ViewportFitBoundsParams }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
-        "@arethetypeswrong/cli": "^0.16.4",
+        "@arethetypeswrong/cli": "^0.17.4",
         "@changesets/cli": "^2.27.9",
         "@microsoft/api-extractor": "^7.47.9",
         "@types/node": "^22.7.4",
@@ -38,12 +38,12 @@
       "dev": true
     },
     "node_modules/@arethetypeswrong/cli": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.16.4.tgz",
-      "integrity": "sha512-qMmdVlJon5FtA+ahn0c1oAVNxiq4xW5lqFiTZ21XHIeVwAVIQ+uRz4UEivqRMsjVV1grzRgJSKqaOrq1MvlVyQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.17.4.tgz",
+      "integrity": "sha512-AeiKxtf67XD/NdOqXgBOE5TZWH3EOCt+0GkbUpekOzngc+Q/cRZ5azjWyMxISxxfp0EItgm5NoSld9p7BAA5xQ==",
       "dev": true,
       "dependencies": {
-        "@arethetypeswrong/core": "0.16.4",
+        "@arethetypeswrong/core": "0.17.4",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
@@ -59,12 +59,13 @@
       }
     },
     "node_modules/@arethetypeswrong/core": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.16.4.tgz",
-      "integrity": "sha512-RI3HXgSuKTfcBf1hSEg1P9/cOvmI0flsMm6/QL3L3wju4AlHDqd55JFPfXs4pzgEAgy5L9pul4/HPPz99x2GvA==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.17.4.tgz",
+      "integrity": "sha512-Izvir8iIoU+X4SKtDAa5kpb+9cpifclzsbA8x/AZY0k0gIfXYQ1fa1B6Epfe6vNA2YfDX8VtrZFgvnXB6aPEoQ==",
       "dev": true,
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.3",
+        "@loaderkit/resolve": "^1.0.2",
         "cjs-module-lexer": "^1.2.3",
         "fflate": "^0.8.2",
         "lru-cache": "^10.4.3",
@@ -106,6 +107,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braidai/lang": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.0.tgz",
+      "integrity": "sha512-xyJYkiyNQtTyCLeHxZmOs7rnB94D+N1IjKNArQIh8+8lTBOY7TFgwEV+Ow5a1uaBi5j2w9fLbWcJFTWLDItl5g==",
+      "dev": true
     },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.0.5",
@@ -881,6 +888,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@loaderkit/resolve": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.4.tgz",
+      "integrity": "sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==",
+      "dev": true,
+      "dependencies": {
+        "@braidai/lang": "^1.0.0"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -2130,9 +2146,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
     },
     "node_modules/clean-stack": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://developers.felt.com",
   "type": "module",
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.16.4",
+    "@arethetypeswrong/cli": "^0.17.4",
     "@changesets/cli": "^2.27.9",
     "@microsoft/api-extractor": "^7.47.9",
     "@types/node": "^22.7.4",
@@ -62,7 +62,7 @@
     "build:docs": "typedoc",
     "build": "npm run build:compile && npm run build:docs",
     "changeset": "changeset",
-    "check:api": "npm run build:compile && attw --pack . && api-extractor run",
+    "check:api": "npm run build:compile && attw --pack . --profile node16 && api-extractor run",
     "check:client-bundle": "npm run build:compile && node ./scripts/check-client-bundle-contents.js",
     "check:docs": "npm run build:docs && bash ./scripts/check-api-docs.sh",
     "check:format": "prettier --check .",

--- a/src/lib/builders.ts
+++ b/src/lib/builders.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import type { FeltController } from "~/client";
+import type { UnwrapPromise } from "./utils";
 
 export function methodMessage<
   TType extends string,
@@ -33,12 +35,14 @@ export function listenerMessageNoParams<TEventName extends string>(
   });
 }
 
+type FeltControllerFunctions = Omit<FeltController, "iframe">;
 export type Method<
-  TRequest extends { type: string; params?: any },
-  TResponse,
+  TRequest extends { type: keyof FeltControllerFunctions; params?: any },
 > = {
   request: TRequest;
-  response: TResponse;
+  response: UnwrapPromise<
+    ReturnType<FeltControllerFunctions[TRequest["type"]]>
+  >;
 };
 
 export type Listener<TOptions, TParams> = {

--- a/src/lib/builders.ts
+++ b/src/lib/builders.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { FeltController } from "~/client";
+import type { FeltController } from "~/modules/main/controller";
 import type { UnwrapPromise } from "./utils";
 
 export function methodMessage<

--- a/src/lib/interface.ts
+++ b/src/lib/interface.ts
@@ -128,32 +128,23 @@ export function listener<TEventName extends keyof ListenerSpec>(
   };
 }
 
-// methods where we write out the entire function signature
-type LiteralMethodKeys = {
-  [K in keyof MethodSpec]: MethodSpec[K] extends (...args: any[]) => any
-    ? K
-    : never;
-}[keyof MethodSpec];
-
-type MaybeOneMethod<K extends keyof Omit<MethodSpec, LiteralMethodKeys>> = {
+type MaybeOneMethod<K extends keyof MethodSpec> = {
   [K1 in K]: MethodSpec[K1]["request"];
 }[K]["params"];
 
-type StandardMethods = Omit<MethodSpec, LiteralMethodKeys>;
-
-type OneMethod<K extends keyof StandardMethods> =
+type OneMethod<K extends keyof MethodSpec> =
   MaybeOneMethod<K> extends undefined ? void : MaybeOneMethod<K>;
 
-type FeltMethod<TKey extends keyof StandardMethods> = (
+type FeltMethod<TKey extends keyof MethodSpec> = (
   payload: OneMethod<TKey>,
-) => Promise<StandardMethods[TKey]["response"]>;
+) => Promise<MethodSpec[TKey]["response"]>;
 
-export function method<TKey extends keyof StandardMethods>(
+export function method<TKey extends keyof MethodSpec>(
   feltWindow: Pick<Window, "postMessage">,
   type: TKey,
   transformer?: (
-    params: StandardMethods[TKey]["request"]["params"],
-  ) => PromiseOrNot<StandardMethods[TKey]["request"]["params"]>,
+    params: MethodSpec[TKey]["request"]["params"],
+  ) => PromiseOrNot<MethodSpec[TKey]["request"]["params"]>,
 ): FeltMethod<TKey> {
   return async (params) => {
     const messageChannel = new MessageChannel();

--- a/src/modules/elements/schema.ts
+++ b/src/modules/elements/schema.ts
@@ -9,14 +9,10 @@ import {
   methodMessage,
 } from "~/lib/builders";
 import type { zInfer } from "~/lib/utils";
-import {
-  type GeoJsonGeometry,
-  SetVisibilityRequestSchema,
-} from "~/modules/shared/types";
+import { SetVisibilityRequestSchema } from "~/modules/shared/types";
 import {
   type Element,
   type ElementChangeCallbackParams,
-  type ElementGroup,
   type ElementGroupChangeCallbackParams,
   ElementCreateSchema,
   ElementUpdateSchema,
@@ -95,31 +91,18 @@ export const elementsSchema = {
 
 export type ElementsSchema = {
   methods: {
-    getElement: Method<zInfer<typeof GetElementMessage>, Element | null>;
-    getElementGeometry: Method<
-      zInfer<typeof GetElementGeometryMessage>,
-      GeoJsonGeometry | null
-    >;
-    getElements: Method<
-      zInfer<typeof GetElementsMessage>,
-      Array<Element | null>
-    >;
-    getElementGroup: Method<
-      zInfer<typeof GetGroupMessage>,
-      ElementGroup | null
-    >;
-    getElementGroups: Method<
-      zInfer<typeof GetGroupsMessage>,
-      Array<ElementGroup | null>
-    >;
+    getElement: Method<zInfer<typeof GetElementMessage>>;
+    getElementGeometry: Method<zInfer<typeof GetElementGeometryMessage>>;
+    getElements: Method<zInfer<typeof GetElementsMessage>>;
+    getElementGroup: Method<zInfer<typeof GetGroupMessage>>;
+    getElementGroups: Method<zInfer<typeof GetGroupsMessage>>;
     setElementGroupVisibility: Method<
-      zInfer<typeof SetElementGroupVisibilityMessage>,
-      void
+      zInfer<typeof SetElementGroupVisibilityMessage>
     >;
 
-    createElement: Method<zInfer<typeof CreateElementMessage>, Element>;
-    updateElement: Method<zInfer<typeof UpdateElementMessage>, Element>;
-    deleteElement: Method<zInfer<typeof DeleteElementMessage>, void>;
+    createElement: Method<zInfer<typeof CreateElementMessage>>;
+    updateElement: Method<zInfer<typeof UpdateElementMessage>>;
+    deleteElement: Method<zInfer<typeof DeleteElementMessage>>;
   };
   listeners: {
     onElementChange: Listener<

--- a/src/modules/layers/features/types.ts
+++ b/src/modules/layers/features/types.ts
@@ -1,4 +1,4 @@
-import type { FeltController } from "~/client";
+import type { FeltController } from "~/modules/main/controller";
 import type { SelectionController } from "~/modules/selection";
 import type {
   FeltBoundary,

--- a/src/modules/layers/schema.ts
+++ b/src/modules/layers/schema.ts
@@ -7,25 +7,20 @@ import {
   type Method,
   methodMessage,
 } from "~/lib/builders";
-import type { UnwrapPromise, zInfer } from "~/lib/utils";
+import type { zInfer } from "~/lib/utils";
 import {
-  type GeoJsonFeature,
   MultiPolygonGeometrySchema,
   SetVisibilityRequestSchema,
   SortConfigSchema,
 } from "~/modules/shared/types";
-import type { LayersController } from "./controller";
 import {
   FiltersSchema,
   GeometryFilterSchema,
   type LayerFilters,
 } from "./filters/types";
 import {
-  type AggregationMethod,
   GetLayerCalculationParamsSchema,
-  type GetLayerCategoriesGroup,
   GetLayerCategoriesParamsSchema,
-  type GetLayerHistogramBin,
   GetLayerHistogramParamsSchema,
 } from "./stats/types";
 import {
@@ -33,13 +28,8 @@ import {
   GetLayerGroupsFilterSchema,
   GetLayersConstraintSchema,
   GetRenderedFeaturesConstraintSchema,
-  type Layer,
   type LayerChangeCallbackParams,
-  type LayerFeature,
-  type LayerGroup,
   type LayerGroupChangeCallbackParams,
-  type LayerSchema,
-  type LegendItem,
   type LegendItemChangeCallbackParams,
   LegendItemIdentifierSchema,
   LegendItemsConstraintSchema,
@@ -252,94 +242,50 @@ export const layersSchema = {
 
 export type LayersSchema = {
   methods: {
-    getLayer: Method<zInfer<typeof GetLayerMessage>, Layer | null>;
-    getLayers: Method<zInfer<typeof GetLayersMessage>, Array<Layer | null>>;
-    setLayerVisibility: Method<zInfer<typeof SetLayerVisibilityMessage>, void>;
-    setLayerStyle: Method<zInfer<typeof SetLayerStyleMessage>, void>;
+    getLayer: Method<zInfer<typeof GetLayerMessage>>;
+    getLayers: Method<zInfer<typeof GetLayersMessage>>;
+    setLayerVisibility: Method<zInfer<typeof SetLayerVisibilityMessage>>;
+    setLayerStyle: Method<zInfer<typeof SetLayerStyleMessage>>;
     setLayerLegendVisibility: Method<
-      zInfer<typeof SetLayerLegendVisibilityMessage>,
-      void
+      zInfer<typeof SetLayerLegendVisibilityMessage>
     >;
 
     createLayersFromGeoJson: Method<
-      zInfer<typeof CreateLayersFromGeoJsonMessage>,
-      {
-        layerGroup: LayerGroup;
-        layers: Array<Layer>;
-      } | null
+      zInfer<typeof CreateLayersFromGeoJsonMessage>
     >;
-    updateLayer: Method<zInfer<typeof UpdateLayerMessage>, Layer>;
-    deleteLayer: Method<zInfer<typeof DeleteLayerMessage>, void>;
+    updateLayer: Method<zInfer<typeof UpdateLayerMessage>>;
+    deleteLayer: Method<zInfer<typeof DeleteLayerMessage>>;
 
-    getLayerGroup: Method<zInfer<typeof GetGroupMessage>, LayerGroup | null>;
-    getLayerGroups: Method<
-      zInfer<typeof GetGroupsMessage>,
-      Array<LayerGroup | null>
-    >;
+    getLayerGroup: Method<zInfer<typeof GetGroupMessage>>;
+    getLayerGroups: Method<zInfer<typeof GetGroupsMessage>>;
     setLayerGroupVisibility: Method<
-      zInfer<typeof SetLayerGroupVisibilityMessage>,
-      void
+      zInfer<typeof SetLayerGroupVisibilityMessage>
     >;
     setLayerGroupLegendVisibility: Method<
-      zInfer<typeof SetLayerGroupLegendVisibilityMessage>,
-      void
+      zInfer<typeof SetLayerGroupLegendVisibilityMessage>
     >;
 
-    getLegendItem: Method<
-      zInfer<typeof GetLegendItemMessage>,
-      LegendItem | null
-    >;
-    getLegendItems: Method<
-      zInfer<typeof GetLegendItemsMessage>,
-      Array<LegendItem | null>
-    >;
+    getLegendItem: Method<zInfer<typeof GetLegendItemMessage>>;
+    getLegendItems: Method<zInfer<typeof GetLegendItemsMessage>>;
     setLegendItemVisibility: Method<
-      zInfer<typeof SetLegendItemVisibilityMessage>,
-      void
+      zInfer<typeof SetLegendItemVisibilityMessage>
     >;
 
-    getLayerFilters: Method<
-      zInfer<typeof GetFiltersMessage>,
-      LayerFilters | null
-    >;
+    getLayerFilters: Method<zInfer<typeof GetFiltersMessage>>;
+    setLayerFilters: Method<zInfer<typeof SetFiltersMessage>>;
 
-    setLayerFilters: Method<zInfer<typeof SetFiltersMessage>, void>;
+    getRenderedFeatures: Method<zInfer<typeof GetRenderedFeaturesMessage>>;
+    getFeature: Method<zInfer<typeof GetFeatureMessage>>;
+    getGeoJsonFeature: Method<zInfer<typeof GetGeoJsonFeatureMessage>>;
 
-    getLayerBoundaries: Method<
-      zInfer<typeof GetLayerBoundariesMessage>,
-      LayerBoundaries | null
-    >;
-    setLayerBoundary: Method<zInfer<typeof SetLayerBoundaryMessage>, void>;
+    getLayerBoundaries: Method<zInfer<typeof GetLayerBoundariesMessage>>;
+    setLayerBoundary: Method<zInfer<typeof SetLayerBoundaryMessage>>;
+    getFeatures: Method<zInfer<typeof GetFeaturesMessage>>;
+    getCategoryData: Method<zInfer<typeof GetLayerCategoriesMessage>>;
+    getHistogramData: Method<zInfer<typeof GetLayerHistogramMessage>>;
+    getAggregates: Method<zInfer<typeof GetLayerCalculationMessage>>;
 
-    getRenderedFeatures: Method<
-      zInfer<typeof GetRenderedFeaturesMessage>,
-      Array<LayerFeature>
-    >;
-    getFeature: Method<zInfer<typeof GetFeatureMessage>, LayerFeature | null>;
-    getFeatures: Method<
-      zInfer<typeof GetFeaturesMessage>,
-      UnwrapPromise<ReturnType<LayersController["getFeatures"]>>
-    >;
-
-    getGeoJsonFeature: Method<
-      zInfer<typeof GetGeoJsonFeatureMessage>,
-      GeoJsonFeature | null
-    >;
-
-    getCategoryData: Method<
-      zInfer<typeof GetLayerCategoriesMessage>,
-      Array<GetLayerCategoriesGroup>
-    >;
-    getHistogramData: Method<
-      zInfer<typeof GetLayerHistogramMessage>,
-      Array<GetLayerHistogramBin>
-    >;
-    getAggregates: Method<
-      zInfer<typeof GetLayerCalculationMessage>,
-      Record<AggregationMethod | "count", number | null>
-    >;
-
-    getLayerSchema: Method<zInfer<typeof GetLayerSchemaMessage>, LayerSchema>;
+    getLayerSchema: Method<zInfer<typeof GetLayerSchemaMessage>>;
   };
   listeners: {
     onLayerChange: Listener<

--- a/src/modules/misc/schema.ts
+++ b/src/modules/misc/schema.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { methodMessage, type Method } from "~/lib/builders";
 import type { ModuleSchema } from "~/lib/ModuleSchema";
 import type { zInfer } from "~/lib/utils";
-import type { MapDetails } from "./types";
 
 const GetMapDetailsMessage = methodMessage("getMapDetails", z.undefined());
 
@@ -13,7 +12,7 @@ export const miscSchema = {
 
 export type MiscSchema = {
   methods: {
-    getMapDetails: Method<zInfer<typeof GetMapDetailsMessage>, MapDetails>;
+    getMapDetails: Method<zInfer<typeof GetMapDetailsMessage>>;
   };
   listeners: {};
 };

--- a/src/modules/selection/schema.ts
+++ b/src/modules/selection/schema.ts
@@ -34,9 +34,9 @@ export const selectionSchema = {
 
 export type SelectionSchema = {
   methods: {
-    getSelection: Method<zInfer<typeof GetSelectionMessage>, Array<EntityNode>>;
-    selectFeature: Method<zInfer<typeof SelectFeatureMessage>, void>;
-    clearSelection: Method<zInfer<typeof ClearSelectionMessage>, void>;
+    getSelection: Method<zInfer<typeof GetSelectionMessage>>;
+    selectFeature: Method<zInfer<typeof SelectFeatureMessage>>;
+    clearSelection: Method<zInfer<typeof ClearSelectionMessage>>;
   };
   listeners: {
     onSelectionChange: ListenerNoOptions<{ selection: Array<EntityNode> }>;

--- a/src/modules/tools/schema.ts
+++ b/src/modules/tools/schema.ts
@@ -12,7 +12,6 @@ import {
   InputToolSettingsSchema,
   ToolSchema,
   type ToolSettingsChangeEvent,
-  type ToolSettingsMap,
   type ToolType,
 } from "./types";
 
@@ -44,13 +43,10 @@ export const toolsSchema = {
 
 export type ToolsSchema = {
   methods: {
-    setTool: Method<zInfer<typeof SetToolMessage>, void>;
-    getTool: Method<zInfer<typeof GetToolMessage>, ToolType | null>;
-    setToolSettings: Method<zInfer<typeof SetToolSettingsMessage>, void>;
-    getToolSettings: Method<
-      zInfer<typeof GetToolSettingsMessage>,
-      ToolSettingsMap[keyof ToolSettingsMap]
-    >;
+    setTool: Method<zInfer<typeof SetToolMessage>>;
+    getTool: Method<zInfer<typeof GetToolMessage>>;
+    setToolSettings: Method<zInfer<typeof SetToolSettingsMessage>>;
+    getToolSettings: Method<zInfer<typeof GetToolSettingsMessage>>;
   };
   listeners: {
     onToolChange: ListenerNoOptions<ToolType | null>;

--- a/src/modules/ui/schema.ts
+++ b/src/modules/ui/schema.ts
@@ -46,14 +46,11 @@ export const uiSchema = {
 
 export type UiSchema = {
   methods: {
-    updateUiControls: Method<zInfer<typeof UiControlsMessage>, void>;
-    setOnMapInteractionsUi: Method<
-      zInfer<typeof OnMapInteractionsMessage>,
-      void
-    >;
+    updateUiControls: Method<zInfer<typeof UiControlsMessage>>;
+    setOnMapInteractionsUi: Method<zInfer<typeof OnMapInteractionsMessage>>;
 
-    showLayerDataTable: Method<zInfer<typeof ShowLayerDataTableMessage>, void>;
-    hideLayerDataTable: Method<zInfer<typeof HideLayerDataTableMessage>, void>;
+    showLayerDataTable: Method<zInfer<typeof ShowLayerDataTableMessage>>;
+    hideLayerDataTable: Method<zInfer<typeof HideLayerDataTableMessage>>;
   };
   listeners: {};
 };

--- a/src/modules/viewport/schema.ts
+++ b/src/modules/viewport/schema.ts
@@ -11,7 +11,6 @@ import {
   SetViewportCenterZoomParamsSchema,
   SetViewportConstraintsParamsSchema,
   ViewportFitBoundsParamsSchema,
-  type ViewportConstraints,
   type ViewportState,
 } from "./types";
 
@@ -55,19 +54,17 @@ export const viewportSchema = {
 
 export type ViewportSchema = {
   methods: {
-    getViewport: Method<zInfer<typeof GetViewportMessage>, ViewportState>;
-    setViewport: Method<zInfer<typeof GotoViewportMessage>, void>;
+    getViewport: Method<zInfer<typeof GetViewportMessage>>;
+    setViewport: Method<zInfer<typeof GotoViewportMessage>>;
 
     getViewportConstraints: Method<
-      zInfer<typeof GetViewportConstraintsMessage>,
-      ViewportConstraints | null
+      zInfer<typeof GetViewportConstraintsMessage>
     >;
     setViewportConstraints: Method<
-      zInfer<typeof SetViewportConstraintsMessage>,
-      void
+      zInfer<typeof SetViewportConstraintsMessage>
     >;
 
-    fitViewportToBounds: Method<zInfer<typeof ViewportFitBoundsMessage>, void>;
+    fitViewportToBounds: Method<zInfer<typeof ViewportFitBoundsMessage>>;
   };
   listeners: {
     onViewportMove: ListenerNoOptions<ViewportState>;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,11 +1,4 @@
-import fs from "fs";
-import path from "path";
 import { defineConfig } from "tsup";
-
-const files = fs.readdirSync("./").filter(isCopiedTargetFile);
-for (const file of files) {
-  fs.unlinkSync(path.join(".", file));
-}
 
 export default defineConfig({
   entryPoints: ["src/client.ts", "src/handler.ts"],
@@ -19,33 +12,3 @@ export default defineConfig({
 
   clean: true,
 });
-
-// move the files to the root for node 10 support (really just to make attw happy)
-// onSuccess cannot be used because it runs before the types are generated.
-process.on("exit", () => {
-  const files = fs.readdirSync("./dist").filter(isDesiredSourceFile);
-  for (const file of files) {
-    fs.copyFileSync(path.join("dist", file), file.replace(".cjs", ".js"));
-  }
-});
-
-/**
- * Selects the files that are in the bundle that need to be copied to the root
- * in order to satisfy Node 10 support. This is necessary because the attw
- * package is not able to opt out of checking the Node 10 compatibility,
- * so we just do this to satisfy it.
- *
- * In general, no one should want Node 10 support - this is a library intended
- * to work in a browser environment.
- */
-function isDesiredSourceFile(file: string) {
-  return (
-    file.endsWith("handler.d.ts") ||
-    file.endsWith("handler.cjs") ||
-    (file.endsWith(".d.ts") && file.includes("types-"))
-  );
-}
-
-function isCopiedTargetFile(file: string) {
-  return isDesiredSourceFile(file) || file.endsWith("handler.js");
-}


### PR DESCRIPTION
## What this does

Reduces repetition in the schema definition, and removes a certain class of inconsistency that can arise. Previously, you were required to fill in the return type of the methods in the schema, and it had to match the controller. This led to either:
- repeating yourself
- making mistakes (there wouldn't always be a type error if one type was a subset of another, and if there were they weren't always obvious)
- having to define an interface/type to reuse between the controller and schema (which led to a tension between DRY and nicer documentation)

Now we derive the schema types from the controller, so there's one source of truth for return types from methods.

I plan to expand on this in other ways, so we can either reduce duplication or have more of these "if you define this thing here you are required to define this thing here"-type locks, which makes adding to the SDK easier.

As part of doing this, I had to drop Node 10 support, which was entirely pointless because this is a client-side library. It was just the the arethetypeswrong package always checked Node 10 compatibility, so we did some horrible hacks to make that pass, even though it was completely pointless.